### PR TITLE
Add concat and < to Series

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Provides the following methods for a Series:
 * comparison operators ==, !=, >=, <=, >, < with another Series or with a numeric type
 * `.diff()`
 * `.where()`
+* `.loc()`
+* `.iloc()`
 * `.abs()`
 * `.pow()`
 * `.count()`
@@ -93,6 +95,7 @@ Provides the following methods for a Series:
 * `<<` operator overloading (pretty printing)
 * `.rolling()` supporting mean, quantile, std, sum for flat windows, triangle windows, and (approximated) exponential windows
 * `arctan2()` element-wise arc tangent of x1/x2 choosing the quadrant correctly
+* `concat()` concatenation of two series
 
 It also provides a SeriesMask class which is the result of any comparison operation and is used as the input to `.where()`.
 

--- a/conan/profiles/android-arm64-v8a
+++ b/conan/profiles/android-arm64-v8a
@@ -13,6 +13,7 @@ os.api_level=21
 android_ndk_installer/r20@bincrafters/stable
 
 [options]
+date:use_system_tz_db=True
 
 [env]
 CONAN_CMAKE_TOOLCHAIN_FILE=$PROFILE_DIR/cmake/android.cmake

--- a/conan/profiles/android-x86_64
+++ b/conan/profiles/android-x86_64
@@ -13,6 +13,7 @@ os.api_level=21
 android_ndk_installer/r20@bincrafters/stable
 
 [options]
+date:use_system_tz_db=True
 
 [env]
 CONAN_CMAKE_TOOLCHAIN_FILE=$PROFILE_DIR/cmake/android.cmake

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -130,6 +130,10 @@ namespace polars {
         return SeriesMask(values() > (arma::ones(size()) * rhs), index());
     }
 
+    SeriesMask Series::operator<(const double &rhs) const {
+        return SeriesMask(values() < (arma::ones(size()) * rhs), index());
+    }
+
     SeriesMask Series::operator>=(const double &rhs) const {
         return SeriesMask(values() >= (arma::ones(size()) * rhs), index());
     }
@@ -742,6 +746,14 @@ namespace polars {
         arma::vec y = rhs.values();
         arma::vec result = numc::arctan2(x, y);
         return Series(result, lhs.index());
+    }
+
+    Series Series::concat(const Series &lhs, const Series &rhs) {
+        arma::vec expanded_values = lhs.values();
+        arma::vec expanded_indices = lhs.index();
+        expanded_values.insert_rows(lhs.values().size(), rhs.values());
+        expanded_indices.insert_rows(lhs.values().size(), rhs.index());
+        return Series( expanded_values, expanded_indices);
     }
 
     /**

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -753,7 +753,7 @@ namespace polars {
         arma::vec expanded_indices = lhs.index();
         expanded_values.insert_rows(lhs.values().size(), rhs.values());
         expanded_indices.insert_rows(lhs.values().size(), rhs.index());
-        return Series( expanded_values, expanded_indices);
+        return Series(expanded_values, expanded_indices);
     }
 
     /**

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -45,6 +45,8 @@ namespace polars {
 
         SeriesMask operator>(const double &rhs) const;
 
+        SeriesMask operator<(const double &rhs) const;
+
         SeriesMask operator>=(const double &rhs) const;
 
         SeriesMask operator<=(const double &rhs) const;
@@ -152,6 +154,8 @@ namespace polars {
         Series tail(int n=5) const;
 
         static Series arctan2(const Series &lhs, const Series &rhs);
+
+        static Series concat(const Series &lhs, const Series &rhs);
 
     protected:
         arma::vec t;

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -776,9 +776,34 @@ TEST(Series, arctan2_regular_case){
 
 TEST(Series, concat){
     EXPECT_PRED2(
-            Series::almost_equal,
-            Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
-            Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6})));
+        Series::almost_equal,
+        Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
+        Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6}))
+    ) << "Expect" << " series become concatenated one to the other.";
+
+    EXPECT_PRED2(
+        Series::almost_equal,
+        Series({1,NAN,NAN,4,5,6},{1,2,3,4,5,6}),
+        Series::concat(Series({1,NAN,NAN},{1,2,3}), Series({4,5,6},{4,5,6}))
+    ) << "Expect" << " series become concatenated one to the other even with NANs.";
+
+    EXPECT_PRED2(
+        Series::almost_equal,
+        Series({1,2,3},{1,2,3}),
+        Series::concat(Series({1,2,3},{1,2,3}), Series({},{}))
+    ) << "Expect" << " input series as we are concatenating an empty series.";
+
+    EXPECT_PRED2(
+        Series::almost_equal,
+        Series({1,2,3},{1,2,3}),
+        Series::concat(Series({},{}), Series({1,2,3},{1,2,3}))
+    ) << "Expect" << " input series as we are concatenating an empty series.";
+
+    EXPECT_PRED2(
+        Series::almost_equal,
+        Series(),
+        Series::concat(Series(), Series())
+     ) << "Expect" << " an empty series.";
 }
 
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -426,6 +426,12 @@ TEST(Series, operator__lt) {
             Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
             polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
     ) << "Expect " << "<= should work per item, including NAN != NAN";
+
+    EXPECT_PRED2(
+            polars::SeriesMask::equal,
+            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) < 0,
+            polars::SeriesMask({0, 1, 0, 0}, {1, 2, 3, 4})
+    ) << "Expect " << "< should work per item, including NAN != NAN";
 }
 
 
@@ -766,6 +772,13 @@ TEST(Series, arctan2_regular_case){
                             Series({1.3, 0.3, 4.5, 5.3, -0.3}, {1, 2, 3, 4, 5}))
     ) << "Expect" << " series where each element is the arctan2 of the corresponding series components in x and y.";
 
+}
+
+TEST(Series, concat){
+    EXPECT_PRED2(
+            Series::almost_equal,
+            Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
+            Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6})));
 }
 
 } // namespace SeriesTests


### PR DESCRIPTION
This PR implements missing logical operator for series and double `<` and a `concat` method.

TODOs:

- [x] Add to readme
- [x] Fix android cross-build