### PR TITLE
Refactor rolling method

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake
 
 class PolarsConan(ConanFile):
     name = "Polars"
-    version = "0.3.0"
+    version = "0.4.0"
     url = "https://github.com/polarsorg/polars"
     license = "MIT License"
     description = "A C++ TimeSeries library that aims to mimic pandas Series"

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -24,7 +24,6 @@
 
 namespace polars {
 
-
     using SeriesMask = polars::SeriesMask;
 
     Series::Series() = default;

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -103,6 +103,11 @@ namespace polars {
                        WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none,
                        double alpha = -1) const;
 
+		Series ewm(SeriesSize windowSize,
+				SeriesSize minPeriods,
+				bool center = true,
+				double alpha = -1) const;
+
         Window rolling(SeriesSize windowSize,
                        SeriesSize minPeriods, /* 0 treated as windowSize */
                        bool center,
@@ -167,6 +172,8 @@ namespace polars {
 
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
     polars::Series _ewm_input_correction(const polars::Series &input);
+
+	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
 }
 
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -100,8 +100,7 @@ namespace polars {
                        SeriesSize minPeriods = 0, /* 0 treated as windowSize */
                        bool center = true,
                        bool symmetric = false,
-                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none,
-                       double alpha = -1) const;
+                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
 
 		Series ewm(SeriesSize windowSize,
 				SeriesSize minPeriods,
@@ -112,8 +111,7 @@ namespace polars {
                        SeriesSize minPeriods, /* 0 treated as windowSize */
                        bool center,
                        bool symmetric,
-                       polars::WindowProcessor::WindowType win_type,
-                       double alpha = -1) const;
+                       polars::WindowProcessor::WindowType win_type) const;
 
         Rolling rolling(SeriesSize windowSize,
                         SeriesSize minPeriods = 0, /* 0 treated as windowSize */
@@ -173,7 +171,7 @@ namespace polars {
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
     polars::Series _ewm_input_correction(const polars::Series &input);
 
-	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
+	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool center, bool symmetric, int centerIdx);
 }
 
 

--- a/src/cpp/polars/WindowProcessor.cpp
+++ b/src/cpp/polars/WindowProcessor.cpp
@@ -117,15 +117,11 @@ namespace polars {
     }
 
     Series Window::mean() {
-        if (win_type_ == WindowProcessor::WindowType::expn) {
-            return ts_.rolling(windowSize_, ExpMean(), minPeriods_, center_, symmetric_, win_type_, alpha_);
-        } else {
-            return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_, win_type_, alpha_);
-        }
+        return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_, win_type_);
     }
 
     Series Window::sum() {
-        return ts_.rolling(windowSize_, Sum(), minPeriods_, center_, symmetric_, win_type_, alpha_);
+        return ts_.rolling(windowSize_, Sum(), minPeriods_, center_, symmetric_, win_type_);
     }
 
 } // polars

--- a/src/cpp/polars/WindowProcessor.h
+++ b/src/cpp/polars/WindowProcessor.h
@@ -113,8 +113,7 @@ namespace polars {
         double default_value = NAN;
     };
 
-    arma::vec calculate_window_weights(polars::WindowProcessor::WindowType win_type, arma::uword windowSize,
-                                       double alpha = -1);
+    arma::vec calculate_window_weights(polars::WindowProcessor::WindowType win_type, arma::uword windowSize);
 
     arma::vec _ewm_correction(const arma::vec &results, const arma::vec &v0, polars::WindowProcessor::WindowType win_type);
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -806,14 +806,6 @@ TEST(Series, concat){
      ) << "Expect" << " an empty series.";
 }
 
-/* THIS IS HOW WE WOULD LIKE IT TO BEHAVE FOR center = false.
-TEST(Series, interval_edges_new) {
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 0) == std::make_tuple(0, 0, 2, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 1) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 2) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
-}*/
 
 TEST(Series, interval_edges) {
 	// Odd WindowSize Even Input
@@ -866,7 +858,4 @@ TEST(Series, interval_edges) {
 	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 3) == std::make_tuple(1, 3, 0, 2));
 	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 3) == std::make_tuple(2, 3, 1, 2));
 }
-
-
-
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -806,4 +806,58 @@ TEST(Series, concat){
      ) << "Expect" << " an empty series.";
 }
 
+TEST(Series, interval_edges) {
+	// Odd WindowSize Even Input
+	EXPECT_TRUE(get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+	EXPECT_TRUE(get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+	EXPECT_TRUE(get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
+
+	// Even WindowSize Odd Input
+	EXPECT_TRUE(get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
+
+	// Odd WindowSize Odd Input
+	EXPECT_TRUE(get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+	EXPECT_TRUE(get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+	EXPECT_TRUE(get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
+
+	// Even WindowSize Even Input
+	EXPECT_TRUE(get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
+
+	// Window = Input
+	EXPECT_TRUE(get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
+}
+
+
+
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -806,56 +806,65 @@ TEST(Series, concat){
      ) << "Expect" << " an empty series.";
 }
 
+/* THIS IS HOW WE WOULD LIKE IT TO BEHAVE FOR center = false.
+TEST(Series, interval_edges_new) {
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 1) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 2) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
+}*/
+
 TEST(Series, interval_edges) {
 	// Odd WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 0) == std::make_tuple(0, 0, 1, 1));
 
-	EXPECT_TRUE(get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 1) == std::make_tuple(0, 2, 0, 2));
 
-	EXPECT_TRUE(get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 5) == std::make_tuple(4, 5, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 5) == std::make_tuple(5, 5, 1, 1));
 
 	// Even WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 6) == std::make_tuple(4, 6, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 6) == std::make_tuple(5, 6, 1, 2));
 
 	// Odd WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 0) == std::make_tuple(0, 0, 1, 1));
 
-	EXPECT_TRUE(get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 1) == std::make_tuple(0, 2, 0, 2));
 
-	EXPECT_TRUE(get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 4) == std::make_tuple(3, 4, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 4) == std::make_tuple(4, 4, 1, 1));
 
 	// Even WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 5) == std::make_tuple(3, 5, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 5) == std::make_tuple(4, 5, 1, 2));
 
 	// Window = Input
-	EXPECT_TRUE(get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 3) == std::make_tuple(2, 3, 1, 2));
 }
 
 

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -14,60 +14,6 @@
 namespace WindowProcessorTests {
 using Series = polars::Series;
 
-// Tests for rolling median
-/*
-TEST(Series, rolling_median_center_false_sym_false){
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, false, false).median(),
-		Series({NAN, NAN, 2.0, 3.0, 4.0}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with odd window and odd input.";
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, false, false).median(),
-			Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
-	) << "Expect " << " output to match pandas with odd window and even input.";
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4}, {1,2,3,4}).rolling(3, false, false).median(),
-			Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
-	) << "Expect " << " output to match pandas with odd window and even input.";
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, false, false).median(),
-			Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
-	) << "Expect " << " output to match pandas with even window and even input.";
-
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, false, false).median(),
-			Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with even window and odd input.";
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3}, {1,2,3}).rolling(2, false, false).median(),
-			Series({NAN, 1.5, 2.5}, {1,2,3})
-	) << "Expect " << " output to match pandas with even window and odd input.";
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, false, false).median(),
-			Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with windowSize = inputSize";
-
-	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4}, {1,2,3,4}).rolling(5, false, false).median(),
-			Series({NAN, NAN, NAN, NAN, 2.5}, {1,2,3,4})
-	) << "Expect " << " output to match pandas with windowSize = inputSize";
-}*/
-
-
 TEST(Series, RollingQuantileTest) {
     EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
                  Series(arma::vec({}), arma::vec({})).rolling(3, polars::Quantile(0.5)))

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -14,6 +14,60 @@
 namespace WindowProcessorTests {
 using Series = polars::Series;
 
+// Tests for rolling median
+/*
+TEST(Series, rolling_median_center_false_sym_false){
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, false, false).median(),
+		Series({NAN, NAN, 2.0, 3.0, 4.0}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with odd window and odd input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, false, false).median(),
+			Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
+	) << "Expect " << " output to match pandas with odd window and even input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4}, {1,2,3,4}).rolling(3, false, false).median(),
+			Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
+	) << "Expect " << " output to match pandas with odd window and even input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, false, false).median(),
+			Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
+	) << "Expect " << " output to match pandas with even window and even input.";
+
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, false, false).median(),
+			Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with even window and odd input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3}, {1,2,3}).rolling(2, false, false).median(),
+			Series({NAN, 1.5, 2.5}, {1,2,3})
+	) << "Expect " << " output to match pandas with even window and odd input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, false, false).median(),
+			Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with windowSize = inputSize";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4}, {1,2,3,4}).rolling(5, false, false).median(),
+			Series({NAN, NAN, NAN, NAN, 2.5}, {1,2,3,4})
+	) << "Expect " << " output to match pandas with windowSize = inputSize";
+}*/
+
+
 TEST(Series, RollingQuantileTest) {
     EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
                  Series(arma::vec({}), arma::vec({})).rolling(3, polars::Quantile(0.5)))


### PR DESCRIPTION
- Extract exp rolling mean from rolling method since it contains substantial logic versus other window types (emulates pandas).

- Extract logic regarding indices as we roll through the input into a separate function `get_interval_edges`

- Pass center to `get_interval_edges`  in preparation for modifications of this function, so it works correctly for center = False.

~~TODO~~ Done in PR #9 
- [x] `get_interval_edges` has the correct behaviour for `center = False`.
- [x]  Make sure tests cover both center = False and center = True cases.
- [x]  Expand testing coverage.
- [x] Check triang wintype is not broken in the process
