### PR TITLE
Refactor rolling method 2 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           name: Unit tests
           command: |
             pipenv run conan source .  --source-folder=source/ci
-            pipenv run conan install . --install-folder=build/ci --build missing --option Polars:with_tests=True
+            pipenv run conan install . --install-folder=build/ci --build missing --profile=../../conan/profiles/ci.conanprofile
             pipenv run conan build .   --source-folder=source/ci --build-folder=build/ci
             build/ci/bin/polars_cpp_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
 
       - run:
           name: Native build
-          command: pipenv run conan create . -s compiler.cppstd=14 --build missing --option Polars:with_tests=True
+          command: pipenv run conan create . -s compiler.cppstd=14 --build missing --profile ./conan/profiles/ci.conanprofile
       - run:
           name: Cross-build android arm64-v8a abi
           command: pipenv run conan create . -s compiler.cppstd=14 --build missing --profile ./conan/profiles/android-arm64-v8a

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           name: Unit tests
           command: |
             pipenv run conan source .  --source-folder=source/ci
-            pipenv run conan install . --install-folder=build/ci --build missing --profile= ./conan/profiles/ci.conanprofile
+            pipenv run conan install . --install-folder=build/ci --build missing --profile ./conan/profiles/ci.conanprofile
             pipenv run conan build .   --source-folder=source/ci --build-folder=build/ci
             build/ci/bin/polars_cpp_test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           name: Unit tests
           command: |
             pipenv run conan source .  --source-folder=source/ci
-            pipenv run conan install . --install-folder=build/ci --build missing --profile=../../conan/profiles/ci.conanprofile
+            pipenv run conan install . --install-folder=build/ci --build missing --profile= ./conan/profiles/ci.conanprofile
             pipenv run conan build .   --source-folder=source/ci --build-folder=build/ci
             build/ci/bin/polars_cpp_test
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Provides the following methods for a Series:
 * `.tail()`
 * `.to_timeseries_map()`
 * `<<` operator overloading (pretty printing)
-* `.rolling()` supporting mean, quantile, std, sum for flat windows, triangle windows, and (approximated) exponential windows
+* `.rolling()` supporting mean, quantile, std, sum for flat windows and triangle windows.
+* `.ewm()` rolling mean for exponential windows.
 * `arctan2()` element-wise arc tangent of x1/x2 choosing the quadrant correctly
 * `concat()` concatenation of two series
 

--- a/conan/profiles/ci.conanprofile
+++ b/conan/profiles/ci.conanprofile
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+build_type=Release
+
+[build_requires]
+
+[options]
+Polars:with_tests=True
+date:use_system_tz_db=True

--- a/conanfile.py
+++ b/conanfile.py
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake
 
 class PolarsConan(ConanFile):
     name = "Polars"
-    version = "0.3.0"
+    version = "0.4.0"
     url = "https://github.com/polarsorg/polars"
     license = "MIT License"
     description = "A C++ TimeSeries library that aims to mimic pandas Series"

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -24,443 +24,444 @@
 
 namespace polars {
 
-    using SeriesMask = polars::SeriesMask;
 
-    Series::Series() = default;
+	using SeriesMask = polars::SeriesMask;
+
+	Series::Series() = default;
 
 
 // todo; check for 1-D series & that the lengths match
-    Series::Series(const arma::vec &v, const arma::vec &t) : t(t), v(v) {
-        //assert(t.n_cols == 1 && v.n_cols == 1);
-        //assert(t.n_rows == v.n_rows);
-    };
+	Series::Series(const arma::vec &v, const arma::vec &t) : t(t), v(v) {
+		//assert(t.n_cols == 1 && v.n_cols == 1);
+		//assert(t.n_rows == v.n_rows);
+	};
 
-    /**
-     * Converting constructor - this takes a SeriesMask and creates a Series from it.
-     *
-     * This is intentionally implicit (not marked explicit) so that a function expecting a Series can be passed a
-     * SeriesMask and it will be automatically converted since this is a loss-less process.
-     */
-    Series::Series(const SeriesMask &sm) : t(sm.index()), v(arma::conv_to<arma::vec>::from(sm.values())) {}
+	/**
+	 * Converting constructor - this takes a SeriesMask and creates a Series from it.
+	 *
+	 * This is intentionally implicit (not marked explicit) so that a function expecting a Series can be passed a
+	 * SeriesMask and it will be automatically converted since this is a loss-less process.
+	 */
+	Series::Series(const SeriesMask &sm) : t(sm.index()), v(arma::conv_to<arma::vec>::from(sm.values())) {}
 
-    Series Series::from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v) {
-        return Series(arma::conv_to<arma::vec>::from(v_v), arma::conv_to<arma::vec>::from(t_v));
-    }
+	Series Series::from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v) {
+		return Series(arma::conv_to<arma::vec>::from(v_v), arma::conv_to<arma::vec>::from(t_v));
+	}
 
-    Series Series::from_map(const std::map<double, double> &iv_map) {
-        arma::vec index(iv_map.size());
-        arma::vec values(iv_map.size());
-        int i = 0;
-        for (auto& pair : iv_map) {
-            index[i] = pair.first;
-            values[i] = pair.second;
-            ++i;
-        }
-        return {values, index};
-    }
+	Series Series::from_map(const std::map<double, double> &iv_map) {
+		arma::vec index(iv_map.size());
+		arma::vec values(iv_map.size());
+		int i = 0;
+		for (auto& pair : iv_map) {
+			index[i] = pair.first;
+			values[i] = pair.second;
+			++i;
+		}
+		return {values, index};
+	}
 
 
 // Series [op] int methods
-    SeriesMask Series::operator==(const int rhs) const {
-        arma::vec rhs_vec = arma::ones(this->size()) * rhs;
-        arma::vec abs_diff = arma::abs(values() - rhs_vec);
-        // We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
-        double threshold = 1E-50;
-        return SeriesMask(abs_diff < threshold, index());
-    }
+	SeriesMask Series::operator==(const int rhs) const {
+		arma::vec rhs_vec = arma::ones(this->size()) * rhs;
+		arma::vec abs_diff = arma::abs(values() - rhs_vec);
+		// We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
+		double threshold = 1E-50;
+		return SeriesMask(abs_diff < threshold, index());
+	}
 
 
-    SeriesMask Series::operator!=(const int rhs) const {  // TODO implement as negation of operator==
-        arma::vec rhs_vec = arma::ones(this->size()) * rhs;
-        arma::vec abs_diff = arma::abs(values() - rhs_vec);
-        // We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
-        double threshold = 1E-50;
-        return SeriesMask(abs_diff > threshold, index());
-    }
+	SeriesMask Series::operator!=(const int rhs) const {  // TODO implement as negation of operator==
+		arma::vec rhs_vec = arma::ones(this->size()) * rhs;
+		arma::vec abs_diff = arma::abs(values() - rhs_vec);
+		// We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
+		double threshold = 1E-50;
+		return SeriesMask(abs_diff > threshold, index());
+	}
 
 
-    // Series [op] Series methods
-    SeriesMask Series::operator==(const Series &rhs) const {
-        // TODO: make this fast enough to always check at runtime
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return SeriesMask(values() == rhs.values(), index());
-    }
+	// Series [op] Series methods
+	SeriesMask Series::operator==(const Series &rhs) const {
+		// TODO: make this fast enough to always check at runtime
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return SeriesMask(values() == rhs.values(), index());
+	}
 
 
-    SeriesMask Series::operator!=(const Series &rhs) const {
-        // TODO: make this fast enough to always check at runtime
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return SeriesMask(values() != rhs.values(), index());
-    }
+	SeriesMask Series::operator!=(const Series &rhs) const {
+		// TODO: make this fast enough to always check at runtime
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return SeriesMask(values() != rhs.values(), index());
+	}
 
 
-    SeriesMask Series::operator>(const Series &rhs) const {
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return SeriesMask(values() > rhs.values(), index());
-    }
+	SeriesMask Series::operator>(const Series &rhs) const {
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return SeriesMask(values() > rhs.values(), index());
+	}
 
 
-    SeriesMask Series::operator<(const Series &rhs) const {
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return polars::SeriesMask(values() < rhs.values(), index());
-    }
+	SeriesMask Series::operator<(const Series &rhs) const {
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return polars::SeriesMask(values() < rhs.values(), index());
+	}
 
 
-    Series Series::operator+(const Series &rhs) const {
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return polars::Series(values() + rhs.values(), index());
-    }
+	Series Series::operator+(const Series &rhs) const {
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return polars::Series(values() + rhs.values(), index());
+	}
 
 
-    Series Series::operator-(const Series &rhs) const {
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return polars::Series(values() - rhs.values(), index());
-    }
+	Series Series::operator-(const Series &rhs) const {
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return polars::Series(values() - rhs.values(), index());
+	}
 
 
-    Series Series::operator*(const Series &rhs) const {
-        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-        return polars::Series(values() % rhs.values(), index());
-    }
+	Series Series::operator*(const Series &rhs) const {
+		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+		return polars::Series(values() % rhs.values(), index());
+	}
 
 
 // Series [op] double methods
-    SeriesMask Series::operator>(const double &rhs) const {
-        return SeriesMask(values() > (arma::ones(size()) * rhs), index());
-    }
+	SeriesMask Series::operator>(const double &rhs) const {
+		return SeriesMask(values() > (arma::ones(size()) * rhs), index());
+	}
 
-    SeriesMask Series::operator<(const double &rhs) const {
-        return SeriesMask(values() < (arma::ones(size()) * rhs), index());
-    }
+	SeriesMask Series::operator<(const double &rhs) const {
+		return SeriesMask(values() < (arma::ones(size()) * rhs), index());
+	}
 
-    SeriesMask Series::operator>=(const double &rhs) const {
-        return SeriesMask(values() >= (arma::ones(size()) * rhs), index());
-    }
+	SeriesMask Series::operator>=(const double &rhs) const {
+		return SeriesMask(values() >= (arma::ones(size()) * rhs), index());
+	}
 
-    SeriesMask Series::operator<=(const double &rhs) const {
-        return SeriesMask(values() <= (arma::ones(size()) * rhs), index());
-    }
+	SeriesMask Series::operator<=(const double &rhs) const {
+		return SeriesMask(values() <= (arma::ones(size()) * rhs), index());
+	}
 
-    Series Series::operator+(const double &rhs) const {
-        return Series(values() + rhs, index());
-    }
-
-
-    Series Series::operator-(const double &rhs) const {
-        return Series(values() - rhs, index());
-    }
+	Series Series::operator+(const double &rhs) const {
+		return Series(values() + rhs, index());
+	}
 
 
-    Series Series::operator*(const double &rhs) const {
-        return Series(values() * rhs, index());
-    }
+	Series Series::operator-(const double &rhs) const {
+		return Series(values() - rhs, index());
+	}
 
 
-// todo; do we need a flavor that *doesn't* take account of NANs?
-    bool Series::equals(const Series &rhs) const {
-        if ((index().n_rows != rhs.index().n_rows)) return false;
-        if ((index().n_cols != rhs.index().n_cols)) return false;
-        if (!polars::numc::equal_handling_nans(values(), rhs.values())) return false;
-        if (any(index() != rhs.index())) return false;
-        return true;
-    }
+	Series Series::operator*(const double &rhs) const {
+		return Series(values() * rhs, index());
+	}
 
 
 // todo; do we need a flavor that *doesn't* take account of NANs?
-    bool Series::almost_equals(const Series &rhs) const {
-        if ((index().n_rows != rhs.index().n_rows)) return false;
-        if ((index().n_cols != rhs.index().n_cols)) return false;
-        if (!polars::numc::almost_equal_handling_nans(values(), rhs.values())) return false;
-        if (any(index() != rhs.index())) return false;
-        return true;
-    }
+	bool Series::equals(const Series &rhs) const {
+		if ((index().n_rows != rhs.index().n_rows)) return false;
+		if ((index().n_cols != rhs.index().n_cols)) return false;
+		if (!polars::numc::equal_handling_nans(values(), rhs.values())) return false;
+		if (any(index() != rhs.index())) return false;
+		return true;
+	}
+
+
+// todo; do we need a flavor that *doesn't* take account of NANs?
+	bool Series::almost_equals(const Series &rhs) const {
+		if ((index().n_rows != rhs.index().n_rows)) return false;
+		if ((index().n_cols != rhs.index().n_cols)) return false;
+		if (!polars::numc::almost_equal_handling_nans(values(), rhs.values())) return false;
+		if (any(index() != rhs.index())) return false;
+		return true;
+	}
 
 // Location.
 
-    Series Series::iloc(int from, int to, int step) const {
+	Series Series::iloc(int from, int to, int step) const {
 
-        if(empty() || (from == to)){
-            return Series();
-        }
+		if(empty() || (from == to)){
+			return Series();
+		}
 
-        arma::uvec pos;
-        int effective_from;
-        int effective_to;
+		arma::uvec pos;
+		int effective_from;
+		int effective_to;
 
-        if(from < 0){
-            effective_from = values().size() + from;
-        } else {
-            effective_from = from;
-        }
+		if(from < 0){
+			effective_from = values().size() + from;
+		} else {
+			effective_from = from;
+		}
 
-        if(to < 0){
-            effective_to = values().size() + to - 1;
-        } else if(to == 0) {
-            effective_to = to;
-        } else {
-            effective_to = to - 1;
-        }
+		if(to < 0){
+			effective_to = values().size() + to - 1;
+		} else if(to == 0) {
+			effective_to = to;
+		} else {
+			effective_to = to - 1;
+		}
 
-        pos = arma::regspace<arma::uvec>(effective_from,  step,  effective_to);
+		pos = arma::regspace<arma::uvec>(effective_from,  step,  effective_to);
 
-        if(pos.size() > size()){
-            pos = pos.subvec(0, size() - 1);
-        }
+		if(pos.size() > size()){
+			pos = pos.subvec(0, size() - 1);
+		}
 
-        return Series(values().elem(pos),index().elem(pos));
-    }
+		return Series(values().elem(pos),index().elem(pos));
+	}
 
-    // TODO: Add slicing logic of the form .iloc(int start, int stop, int step=1) so it can be called like ser.iloc(0, -10).
-    Series Series::iloc(const arma::uvec &pos) const {
-        return Series(values().elem(pos), index().elem(pos));
-    }
+	// TODO: Add slicing logic of the form .iloc(int start, int stop, int step=1) so it can be called like ser.iloc(0, -10).
+	Series Series::iloc(const arma::uvec &pos) const {
+		return Series(values().elem(pos), index().elem(pos));
+	}
 
 
-    double Series::iloc(arma::uword pos) const {
-        arma::vec val = values().elem(arma::uvec{pos});
-        return val[0];
-    }
+	double Series::iloc(arma::uword pos) const {
+		arma::vec val = values().elem(arma::uvec{pos});
+		return val[0];
+	}
 
 // by label of indices
-    Series Series::loc(const arma::vec &index_labels) const {
+	Series Series::loc(const arma::vec &index_labels) const {
 
-        std::vector<int> indices;
+		std::vector<int> indices;
 
-        for (int j = 0; j < index_labels.n_elem; j++) {
+		for (int j = 0; j < index_labels.n_elem; j++) {
 
-            arma::uvec idx = arma::find(index() == index_labels[j]);
+			arma::uvec idx = arma::find(index() == index_labels[j]);
 
-            if (!idx.empty()) {
-                indices.push_back(idx[0]);
-            }
-        }
+			if (!idx.empty()) {
+				indices.push_back(idx[0]);
+			}
+		}
 
-        if (indices.empty()) {
-            return Series();
-        } else {
-            arma::uvec indices_v = arma::conv_to<arma::uvec>::from(indices);
-            return Series(values().elem(indices_v), index().elem(indices_v));
-        }
-    }
+		if (indices.empty()) {
+			return Series();
+		} else {
+			arma::uvec indices_v = arma::conv_to<arma::uvec>::from(indices);
+			return Series(values().elem(indices_v), index().elem(indices_v));
+		}
+	}
 
-    Series Series::loc(arma::uword pos) const {
-        arma::uvec idx = arma::find(index() == pos);
+	Series Series::loc(arma::uword pos) const {
+		arma::uvec idx = arma::find(index() == pos);
 
-        if (!idx.empty()) {
-            return Series(values(), index()).iloc(idx);
-        } else {
-            return Series();
-        }
-    }
+		if (!idx.empty()) {
+			return Series(values(), index()).iloc(idx);
+		} else {
+			return Series();
+		}
+	}
 
-    Series Series::where(const SeriesMask &condition, double other) const {
-        arma::vec result = values();
-        result.elem(find((!condition).values())).fill(other);
-        return Series(result, index());
-    }
-
-
-    Series Series::diff() const {
-
-        arma::uword resultSize = values().size();
-
-        arma::vec resultv(resultSize);
-
-        double previousValue = NAN;
-        for (arma::uword idx = 0; idx < resultSize; idx++) {
-            resultv[idx] = values()[idx] - previousValue;
-            previousValue = values()[idx];
-        }
-
-        return Series(resultv, index());
-    }
+	Series Series::where(const SeriesMask &condition, double other) const {
+		arma::vec result = values();
+		result.elem(find((!condition).values())).fill(other);
+		return Series(result, index());
+	}
 
 
-    Series Series::abs() const {
-        return Series(arma::abs(values()), index());
-    }
+	Series Series::diff() const {
 
-    double Series::quantile(double q) const {
-        return polars::numc::quantile(values(), q);
-    }
+		arma::uword resultSize = values().size();
 
-    Series Series::fillna(double value) const {
-        arma::vec vals = values();
-        vals.replace(arma::datum::nan, value);
-        return Series(vals, index());
-    }
+		arma::vec resultv(resultSize);
 
-    Series Series::dropna() const {
-        // Get indices of finite elements
-        arma::uvec indices = arma::sort(arma::join_cols(
-                arma::find_finite(values()),
-                arma::find(arma::abs(values()) == arma::datum::inf))
-        );
-        return Series(values().elem(indices), index().elem(indices));
-    }
+		double previousValue = NAN;
+		for (arma::uword idx = 0; idx < resultSize; idx++) {
+			resultv[idx] = values()[idx] - previousValue;
+			previousValue = values()[idx];
+		}
+
+		return Series(resultv, index());
+	}
 
 
-    arma::vec calculate_window_weights(
-            polars::WindowProcessor::WindowType win_type,
-            arma::uword windowSize
-    ) {
-        switch (win_type) {
-            case (polars::WindowProcessor::WindowType::none):
-                return arma::ones(windowSize);
-            case (polars::WindowProcessor::WindowType::triang):
-                return polars::numc::triang(windowSize);
-            default:
-                return arma::ones(windowSize);
-        }
-    }
+	Series Series::abs() const {
+		return Series(arma::abs(values()), index());
+	}
 
-    // TODO: This method needs to be re-factored.
-    arma::vec _ewm_correction(const arma::vec &results, const arma::vec &vals,
-                                      polars::WindowProcessor::WindowType win_type) {
-        /* Method that shifts result from rolling average with exp window so it yields correct normalisation and allows usage
-         * of rolling method hereby implemented.
-         * This matches pandas ewm for its default case */
+	double Series::quantile(double q) const {
+		return polars::numc::quantile(values(), q);
+	}
 
-        arma::uvec res_fin = arma::find_finite(results);
+	Series Series::fillna(double value) const {
+		arma::vec vals = values();
+		vals.replace(arma::datum::nan, value);
+		return Series(vals, index());
+	}
 
-        if (results.empty() || res_fin.empty()){
-            arma::vec effective_results(vals.size());
-            effective_results.fill(NAN);
-            return effective_results;
-        }
+	Series Series::dropna() const {
+		// Get indices of finite elements
+		arma::uvec indices = arma::sort(arma::join_cols(
+				arma::find_finite(values()),
+				arma::find(arma::abs(values()) == arma::datum::inf))
+		);
+		return Series(values().elem(indices), index().elem(indices));
+	}
 
-        if (win_type == polars::WindowProcessor::WindowType::expn) {
-            // Correction to match pandas ewm - shift by one.
-            arma::vec effective_results = results;
-            arma::vec results_ewm;
-            int missing_initial_nans =  0;
 
-            // Check if it was a case of originally front NANs - no added padding
-            arma::uvec finite_values_idx = arma::find_finite(vals);
-            if(finite_values_idx[0] != 0){
-                // we had originally some NANs.
-                missing_initial_nans = finite_values_idx[0];
-            }
+	arma::vec calculate_window_weights(
+			polars::WindowProcessor::WindowType win_type,
+			arma::uword windowSize
+	) {
+		switch (win_type) {
+			case (polars::WindowProcessor::WindowType::none):
+				return arma::ones(windowSize);
+			case (polars::WindowProcessor::WindowType::triang):
+				return polars::numc::triang(windowSize);
+			default:
+				return arma::ones(windowSize);
+		}
+	}
 
-            arma::vec effective_vals = vals.subvec(missing_initial_nans, vals.size() - 1);
+	// TODO: This method needs to be re-factored.
+	arma::vec _ewm_correction(const arma::vec &results, const arma::vec &vals,
+							  polars::WindowProcessor::WindowType win_type) {
+		/* Method that shifts result from rolling average with exp window so it yields correct normalisation and allows usage
+		 * of rolling method hereby implemented.
+		 * This matches pandas ewm for its default case */
 
-            // For the cases in which window_size < size we need to correct
-            if( (results.size() > effective_vals.size())){
-                effective_results = effective_results.elem( arma::find_finite(effective_results) );
-                effective_results = effective_results.head(effective_vals.size());
-            }
+		arma::uvec res_fin = arma::find_finite(results);
 
-            if ( effective_results.at(0) == effective_vals[0] ){
-                // difference of 1 for center = False.
-                results_ewm = effective_results;
-            } else {
-                results_ewm.copy_size(effective_results) ;
-                results_ewm.at(0) = vals[0];
+		if (results.empty() || res_fin.empty()){
+			arma::vec effective_results(vals.size());
+			effective_results.fill(NAN);
+			return effective_results;
+		}
 
-                for (int j = 1; j < results_ewm.n_elem; j++) {
-                    results_ewm[j] = effective_results[j - 1];
-                }
-            }
+		if (win_type == polars::WindowProcessor::WindowType::expn) {
+			// Correction to match pandas ewm - shift by one.
+			arma::vec effective_results = results;
+			arma::vec results_ewm;
+			int missing_initial_nans =  0;
 
-            if(missing_initial_nans > 0){
-                auto added_nans = vals.size() - results_ewm.size();
-                arma::vec pn(added_nans);
-                pn.fill(NAN);
-                return arma::join_cols(pn, results_ewm);
-            } else {
-                return results_ewm;
-            }
+			// Check if it was a case of originally front NANs - no added padding
+			arma::uvec finite_values_idx = arma::find_finite(vals);
+			if(finite_values_idx[0] != 0){
+				// we had originally some NANs.
+				missing_initial_nans = finite_values_idx[0];
+			}
 
-        } else {
-            return results;
-        }
-    }
+			arma::vec effective_vals = vals.subvec(missing_initial_nans, vals.size() - 1);
 
-    // TODO: Combine cases here with those in input for exponential case.
-    polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input){
-        // This is required because of relative size of window size vs array size.
+			// For the cases in which window_size < size we need to correct
+			if( (results.size() > effective_vals.size())){
+				effective_results = effective_results.elem( arma::find_finite(effective_results) );
+				effective_results = effective_results.head(effective_vals.size());
+			}
 
-        if(input.size() == 1){
-            return input;
-        }
+			if ( effective_results.at(0) == effective_vals[0] ){
+				// difference of 1 for center = False.
+				results_ewm = effective_results;
+			} else {
+				results_ewm.copy_size(effective_results) ;
+				results_ewm.at(0) = vals[0];
 
-        auto n = window_size / 2;
-        if(input.size() % 2 == 0){ n = n - 1; };
+				for (int j = 1; j < results_ewm.n_elem; j++) {
+					results_ewm[j] = effective_results[j - 1];
+				}
+			}
 
-        // Get index delta
-        auto ts = input.index();
-        double delta = std::ceil(std::abs(ts(1) -  ts(0)));
+			if(missing_initial_nans > 0){
+				auto added_nans = vals.size() - results_ewm.size();
+				arma::vec pn(added_nans);
+				pn.fill(NAN);
+				return arma::join_cols(pn, results_ewm);
+			} else {
+				return results_ewm;
+			}
 
-        // Vector with n nans
-        arma::vec multi_nan(n);
-        multi_nan.fill(NAN);
+		} else {
+			return results;
+		}
+	}
 
-        // Vector with single nan
-        arma::vec single_nan(1);
-        single_nan.fill(NAN);
+	// TODO: Combine cases here with those in input for exponential case.
+	polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input){
+		// This is required because of relative size of window size vs array size.
 
-        // Base case is padding goes to the right
-        arma::vec new_input = arma::join_cols(input.values(),  multi_nan);
+		if(input.size() == 1){
+			return input;
+		}
 
-        auto start_idx = ts(0);
-        auto end_idx = ts(ts.size()-1) + n * delta;
-        auto effective_size = n + input.size();
+		auto n = window_size / 2;
+		if(input.size() % 2 == 0){ n = n - 1; };
 
-        if (center == false){
+		// Get index delta
+		auto ts = input.index();
+		double delta = std::ceil(std::abs(ts(1) -  ts(0)));
 
-            if( window_size > input.size() + 1 ){
-                new_input = arma::join_cols(multi_nan, input.values());
-                start_idx = start_idx - n * delta;
-                end_idx = end_idx - n * delta;
-            } else if (n == 1) {
-                new_input = arma::join_cols(single_nan, arma::join_cols(single_nan, input.values()));
-                start_idx = start_idx - 2 * delta;
-                end_idx = end_idx - delta;
+		// Vector with n nans
+		arma::vec multi_nan(n);
+		multi_nan.fill(NAN);
 
-                effective_size = effective_size + 1;
-            } else if (n == 2) {
-                new_input = arma::join_cols(single_nan, arma::join_cols(input.values(), single_nan));
-                start_idx = start_idx - delta;
-                end_idx = end_idx - delta;
-            }
-        }
+		// Vector with single nan
+		arma::vec single_nan(1);
+		single_nan.fill(NAN);
 
-        arma::vec new_timestamps = arma::linspace(start_idx, end_idx, effective_size);
+		// Base case is padding goes to the right
+		arma::vec new_input = arma::join_cols(input.values(),  multi_nan);
 
-        return Series(new_input, new_timestamps);
-    }
+		auto start_idx = ts(0);
+		auto end_idx = ts(ts.size()-1) + n * delta;
+		auto effective_size = n + input.size();
 
-    // TODO: Refactor this method and combine with window_size_correction since similar logic
-    polars::Series _ewm_input_correction(const polars::Series &input){
-        // only gets called when window_size < input.size() and we have win_type = expn
-        Series new_input = input;
+		if (center == false){
 
-        if(input.empty() || input.dropna().empty()){
-            return input;
-        }
+			if( window_size > input.size() + 1 ){
+				new_input = arma::join_cols(multi_nan, input.values());
+				start_idx = start_idx - n * delta;
+				end_idx = end_idx - n * delta;
+			} else if (n == 1) {
+				new_input = arma::join_cols(single_nan, arma::join_cols(single_nan, input.values()));
+				start_idx = start_idx - 2 * delta;
+				end_idx = end_idx - delta;
 
-        // remove front NANs
-        if(std::isnan(input.values()(0))){
-            arma::uvec finite_input_idx = arma::find_finite(input.values());
-            auto number_of_nans = finite_input_idx(0);
-            new_input = input.iloc(number_of_nans, input.size());
-        }
+				effective_size = effective_size + 1;
+			} else if (n == 2) {
+				new_input = arma::join_cols(single_nan, arma::join_cols(input.values(), single_nan));
+				start_idx = start_idx - delta;
+				end_idx = end_idx - delta;
+			}
+		}
 
-        arma::vec v(new_input.size());
-        v.fill(NAN);
-        arma::vec new_values = arma::join_cols(v, new_input.values());
+		arma::vec new_timestamps = arma::linspace(start_idx, end_idx, effective_size);
 
-        // Get new timestamps
-        auto ts = new_input.index();
-        auto delta = std::ceil(std::abs(input.index()(1) -  input.index()(0))); // use original input
+		return Series(new_input, new_timestamps);
+	}
 
-        auto new_index_0 = ts(0) - new_input.size() * delta;
-        arma::vec new_timestamps = arma::linspace(new_index_0, ts(ts.size()-1), 2 * new_input.size());
+	// TODO: Refactor this method and combine with window_size_correction since similar logic
+	polars::Series _ewm_input_correction(const polars::Series &input){
+		// only gets called when window_size < input.size() and we have win_type = expn
+		Series new_input = input;
 
-        return Series(new_values, new_timestamps);
-    }
+		if(input.empty() || input.dropna().empty()){
+			return input;
+		}
 
-    std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool center, bool symmetric, int centerIdx){
+		// remove front NANs
+		if(std::isnan(input.values()(0))){
+			arma::uvec finite_input_idx = arma::find_finite(input.values());
+			auto number_of_nans = finite_input_idx(0);
+			new_input = input.iloc(number_of_nans, input.size());
+		}
+
+		arma::vec v(new_input.size());
+		v.fill(NAN);
+		arma::vec new_values = arma::join_cols(v, new_input.values());
+
+		// Get new timestamps
+		auto ts = new_input.index();
+		auto delta = std::ceil(std::abs(input.index()(1) -  input.index()(0))); // use original input
+
+		auto new_index_0 = ts(0) - new_input.size() * delta;
+		arma::vec new_timestamps = arma::linspace(new_index_0, ts(ts.size()-1), 2 * new_input.size());
+
+		return Series(new_values, new_timestamps);
+	}
+
+	std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx) {
 
 		arma::uword centerOffset = round(((float) windowSize - 1) / 2.0);
 
@@ -510,10 +511,24 @@ namespace polars {
 			}
 		}
 		return {leftIdx, rightIdx, weightLeftIdx, weightRightIdx};
-    }
+	}
 
-    Series
-    Series::ewm(SeriesSize windowSize, SeriesSize minPeriods, bool center, double alpha) const {
+	Series _align_to_left(Series input, int windowSize) {
+		// Only need to realign for center=False and windowSize > input.size()
+		arma::vec moved_values = arma::zeros(windowSize - 1) * NAN;
+
+		auto ceil_half = std::ceil((windowSize-1.0)/2.0);
+		auto rolling_start_idx = ceil_half;
+		auto rolling_end_idx = input.size() - (windowSize - ceil_half);
+
+		arma::vec rolling_values = input.values().subvec(rolling_start_idx, rolling_end_idx);
+		moved_values.insert_rows(windowSize-1, rolling_values);
+		return polars::Series(moved_values, input.index());
+
+	};
+
+	Series
+	Series::ewm(SeriesSize windowSize, SeriesSize minPeriods, bool center, double alpha) const {
 		arma::vec input_values = v;
 		arma::vec input_idx = t;
 
@@ -534,12 +549,12 @@ namespace polars {
 			int leftIdx, rightIdx, weightLeftIdx, weightRightIdx;
 			std::tie(
 					leftIdx, rightIdx, weightLeftIdx, weightRightIdx
-			) = get_interval_edges(windowSize, input_idx.size(), center, false, centerIdx);
+			) = _get_interval_edges(windowSize, input_idx.size(), false, centerIdx);
 			arma::vec values = input_values.subvec(leftIdx, rightIdx);
 
 			// Define weights vector required for specific windows
 			arma::vec exponential_weights = reverse(
-				polars::numc::exponential(windowSize, -1. / log(1 - alpha), false, 0)
+					polars::numc::exponential(windowSize, -1. / log(1 - alpha), false, 0)
 			);
 			arma::vec weights(arma::size(values));
 			weights = exponential_weights.subvec(weightLeftIdx, weightRightIdx);
@@ -554,262 +569,264 @@ namespace polars {
 		}
 
 		Series result = Series(
-			polars::_ewm_correction(resultv, v, polars::WindowProcessor::WindowType::expn), t);
+				polars::_ewm_correction(resultv, v, polars::WindowProcessor::WindowType::expn), t);
 
 		if(size() > 0 & windowSize > size()){
 			return Series(result.values().head(size()), t);
 		} else {
 			return result;
 		}
-    }
+	}
 
 // todo; allow passing in transformation function rather than WindowProcessor.
-    Series
-    Series::rolling(SeriesSize windowSize, const polars::WindowProcessor &processor, SeriesSize minPeriods,
-                    bool center, bool symmetric, polars::WindowProcessor::WindowType win_type) const {
+	Series
+	Series::rolling(SeriesSize windowSize, const polars::WindowProcessor &processor, SeriesSize minPeriods,
+					bool center, bool symmetric, polars::WindowProcessor::WindowType win_type) const {
 
-        //assert(center); // todo; implement center:false
-        //assert(windowSize > 0);
-        //assert(windowSize % 2 == 0); // TODO: Make symmetric = true work for even windows. See tests for reference.
-        arma::vec input_values = v;
-        arma::vec input_idx = t;
+		//assert(center); // todo; implement center:false
+		//assert(windowSize > 0);
+		//assert(windowSize % 2 == 0); // TODO: Make symmetric = true work for even windows. See tests for reference.
+		arma::vec input_values = v;
+		arma::vec input_idx = t;
 
-        if((size() > 0 && windowSize > size())) {
-            // This deals with issues of alignment that arises with non linear windows.
-            Series padded_input = _window_size_correction(windowSize, center, *this);
-            input_values = padded_input.values();
-            input_idx = padded_input.index();
-        }
+		if((size() > 0 && windowSize > size())) {
+			// This deals with issues of alignment that arises with non linear windows.
+			Series padded_input = _window_size_correction(windowSize, center, *this);
+			input_values = padded_input.values();
+			input_idx = padded_input.index();
+		}
 
-        if (minPeriods == 0) {
-            minPeriods = windowSize;
-        }
+		if (minPeriods == 0) {
+			minPeriods = windowSize;
+		}
 
-        arma::vec resultv(arma::size(input_values));
+		arma::vec resultv(arma::size(input_values));
 
-        // roll a window [left,right], of up to size windowSize, centered on centerIdx, and hand to processor if there are minPeriods finite values.
-        for (arma::uword centerIdx = 0; centerIdx < input_idx.size(); centerIdx++) {
+		// roll a window [left,right], of up to size windowSize, centered on centerIdx, and hand to processor if there are minPeriods finite values.
+		for (arma::uword centerIdx = 0; centerIdx < input_idx.size(); centerIdx++) {
 			int leftIdx, rightIdx, weightLeftIdx, weightRightIdx;
 			std::tie(
-				leftIdx, rightIdx, weightLeftIdx, weightRightIdx
-			) = get_interval_edges(windowSize, input_idx.size(), center, symmetric, centerIdx);
-            arma::vec values = input_values.subvec(leftIdx, rightIdx);
+					leftIdx, rightIdx, weightLeftIdx, weightRightIdx
+			) = _get_interval_edges(windowSize, input_idx.size(), symmetric, centerIdx);
+			arma::vec values = input_values.subvec(leftIdx, rightIdx);
+			// Define weights vector required for specific windows
+			arma::vec weights(arma::size(values));
+			weights = polars::calculate_window_weights(win_type, windowSize).subvec(weightLeftIdx, weightRightIdx);
 
-            // Define weights vector required for specific windows
-            arma::vec weights(arma::size(values));
-            weights = polars::calculate_window_weights(win_type, windowSize).subvec(weightLeftIdx, weightRightIdx);
+			const Series subSeries = Series(values, input_idx.subvec(leftIdx, rightIdx));
 
-            const Series subSeries = Series(values, input_idx.subvec(leftIdx, rightIdx));
+			if ( subSeries.finiteSize() >= minPeriods) {
+				resultv(centerIdx) = processor.processWindow(subSeries, weights);
+			} else {
+				resultv(centerIdx) = processor.defaultValue();
+			}
+		}
 
-            if (subSeries.finiteSize() >= minPeriods) {
-                resultv(centerIdx) = processor.processWindow(subSeries, weights);
-            } else {
-                resultv(centerIdx) = processor.defaultValue();
-            }
-        }
+		Series result = Series(resultv, t);
 
-        Series result = Series(resultv, t);
+		if(size() > 0 & windowSize > size()){
+			return Series(result.values().head(size()), t);
+		} else {
+			if( (center == true) || (windowSize <= 2) ){
+				return result;
+			} else {
+				return _align_to_left(result, windowSize);
+			}
+		}
+	}
 
-        if(size() > 0 & windowSize > size()){
-            return Series(result.values().head(size()), t);
-        } else {
-            return result;
-        }
-        //return result;
-    }
+	Window Series::rolling(SeriesSize windowSize,
+						   SeriesSize minPeriods,
+						   bool center,
+						   bool symmetric,
+						   polars::WindowProcessor::WindowType win_type) const {
+		return Window((*this), windowSize, minPeriods, center, symmetric, win_type);
+	};
 
-    Window Series::rolling(SeriesSize windowSize,
-                   SeriesSize minPeriods,
-                   bool center,
-                   bool symmetric,
-                   polars::WindowProcessor::WindowType win_type) const {
-        return Window((*this), windowSize, minPeriods, center, symmetric, win_type);
-    };
-
-    Rolling Series::rolling(SeriesSize windowSize,
-                    SeriesSize minPeriods,
-                    bool center,
-                    bool symmetric) const {
-        return Rolling((*this), windowSize, minPeriods, center, symmetric);
-    };
-
-
-    Series Series::clip(double lower_limit, double upper_limit) const {
-        SeriesMask upper = SeriesMask(values() < upper_limit, index());
-        SeriesMask lower = SeriesMask(values() > lower_limit, index());
-        return Series(values(), index()).where(upper, upper_limit).where(lower, lower_limit);
-    };
+	Rolling Series::rolling(SeriesSize windowSize,
+							SeriesSize minPeriods,
+							bool center,
+							bool symmetric) const {
+		return Rolling((*this), windowSize, minPeriods, center, symmetric);
+	};
 
 
-    Series Series::pow(double power) const {
-        return Series(arma::pow(values(), power), index());
-    }
+	Series Series::clip(double lower_limit, double upper_limit) const {
+		SeriesMask upper = SeriesMask(values() < upper_limit, index());
+		SeriesMask lower = SeriesMask(values() > lower_limit, index());
+		return Series(values(), index()).where(upper, upper_limit).where(lower, lower_limit);
+	};
 
 
-    int Series::count() const {
-        return finiteSize();
-    }
+	Series Series::pow(double power) const {
+		return Series(arma::pow(values(), power), index());
+	}
 
 
-    double Series::sum() const {
-        arma::vec finites = finiteValues();
-        if (finites.size() == 0) {
-            return NAN;
-        } else {
-            return arma::sum(finites);
-        }
-    }
+	int Series::count() const {
+		return finiteSize();
+	}
 
 
-    double Series::mean() const {
-        arma::vec finites = finiteValues();
-        if (finites.size() == 0) {
-            return NAN;
-        } else {
-            return arma::mean(finites);
-        }
-    }
+	double Series::sum() const {
+		arma::vec finites = finiteValues();
+		if (finites.size() == 0) {
+			return NAN;
+		} else {
+			return arma::sum(finites);
+		}
+	}
 
 
-    double Series::std(int ddof) const {
-        arma::vec finites = finiteValues();
-        if (ddof < 0) {
-            ddof = 0;
-        }
-        auto n = finites.size();
-        if (n <= ddof) {
-            return NAN;
-        } else {
-            auto dev = (*this) - this->mean();
-            auto squared_deviation = dev.pow(2);
-            return std::pow(squared_deviation.sum() / (n - ddof), 0.5);
-        }
-    }
+	double Series::mean() const {
+		arma::vec finites = finiteValues();
+		if (finites.size() == 0) {
+			return NAN;
+		} else {
+			return arma::mean(finites);
+		}
+	}
 
 
-    Series::SeriesSize Series::size() const {
-        //assert(index().size() == values().size());
-        return index().size();
-    }
+	double Series::std(int ddof) const {
+		arma::vec finites = finiteValues();
+		if (ddof < 0) {
+			ddof = 0;
+		}
+		auto n = finites.size();
+		if (n <= ddof) {
+			return NAN;
+		} else {
+			auto dev = (*this) - this->mean();
+			auto squared_deviation = dev.pow(2);
+			return std::pow(squared_deviation.sum() / (n - ddof), 0.5);
+		}
+	}
 
 
-    arma::vec Series::finiteValues() const {
-        return values().elem(find_finite(values()));
-    }
+	Series::SeriesSize Series::size() const {
+		//assert(index().size() == values().size());
+		return index().size();
+	}
 
 
-    Series::SeriesSize Series::finiteSize() const {
-        //assert(index().size() == values().size());
-        return finiteValues().size();
-    }
+	arma::vec Series::finiteValues() const {
+		return values().elem(find_finite(values()));
+	}
+
+
+	Series::SeriesSize Series::finiteSize() const {
+		//assert(index().size() == values().size());
+		return finiteValues().size();
+	}
 
 
 // done this way so default copy / assignment works.
 // todo; make copies of indices share memory as they are const?
-    const arma::vec Series::index() const {
-        return t;
-    }
+	const arma::vec Series::index() const {
+		return t;
+	}
 
 
-    const arma::vec Series::values() const {
-        return v;
-    }
+	const arma::vec Series::values() const {
+		return v;
+	}
 
 
-    bool Series::equal(const Series &lhs, const Series &rhs) {
-        return lhs.equals(rhs);
-    }
+	bool Series::equal(const Series &lhs, const Series &rhs) {
+		return lhs.equals(rhs);
+	}
 
 
-    bool Series::almost_equal(const Series &lhs, const Series &rhs) {
-        return lhs.almost_equals(rhs);
-    }
+	bool Series::almost_equal(const Series &lhs, const Series &rhs) {
+		return lhs.almost_equals(rhs);
+	}
 
 
-    bool Series::not_equal(const Series &lhs, const Series &rhs) {
-        return !lhs.equals(rhs);
-    }
+	bool Series::not_equal(const Series &lhs, const Series &rhs) {
+		return !lhs.equals(rhs);
+	}
 
-    Series Series::apply(double (*f)(double)) const {
-        arma::vec vals = values();
-        vals.transform([=](double val) { return (f(val)); });
-        return Series(vals, index());
-    }
+	Series Series::apply(double (*f)(double)) const {
+		arma::vec vals = values();
+		vals.transform([=](double val) { return (f(val)); });
+		return Series(vals, index());
+	}
 
-    Series Series::index_as_series() const {
-        return Series(index(), index());
-    }
+	Series Series::index_as_series() const {
+		return Series(index(), index());
+	}
 
-    std::map<double, double> Series::to_map() const {
+	std::map<double, double> Series::to_map() const {
 
-        std::map<double, double> m;
-        // put pairs into map
-        for (int i = 0; i < size(); i++) {
-            m.insert(std::make_pair(index()[i], values()[i]));
-        }
+		std::map<double, double> m;
+		// put pairs into map
+		for (int i = 0; i < size(); i++) {
+			m.insert(std::make_pair(index()[i], values()[i]));
+		}
 
-        return m;
-    }
+		return m;
+	}
 
-    bool Series::empty() const {
-        return (index().is_empty() & values().is_empty());
-    }
+	bool Series::empty() const {
+		return (index().is_empty() & values().is_empty());
+	}
 
-    // TODO: Modify head once iloc has been refactored to accept slicing logic.
-    Series Series::head(int n) const  {
-        Series ser(values(), index());
-        if(n >= ser.size()){
-            return ser;
-        } else {
-            arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(0, n));
-            return ser.iloc(indices);
-        }
-    }
+	// TODO: Modify head once iloc has been refactored to accept slicing logic.
+	Series Series::head(int n) const  {
+		Series ser(values(), index());
+		if(n >= ser.size()){
+			return ser;
+		} else {
+			arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(0, n));
+			return ser.iloc(indices);
+		}
+	}
 
-    // TODO: Modify tail once iloc has been refactored to accept slicing logic.
-    Series Series::tail(int n) const  {
+	// TODO: Modify tail once iloc has been refactored to accept slicing logic.
+	Series Series::tail(int n) const  {
 
-        Series ser(values(), index());
+		Series ser(values(), index());
 
-        if(n >= ser.size()){
-            return ser;
-        } else {
-            arma::uword l = ser.size() - n;
-            arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(l, ser.size()));
-            return ser.iloc(indices);
-        }
-    }
+		if(n >= ser.size()){
+			return ser;
+		} else {
+			arma::uword l = ser.size() - n;
+			arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(l, ser.size()));
+			return ser.iloc(indices);
+		}
+	}
 
-    Series Series::arctan2(const Series &lhs, const Series &rhs) {
-        arma::vec x = lhs.values();
-        arma::vec y = rhs.values();
-        arma::vec result = numc::arctan2(x, y);
-        return Series(result, lhs.index());
-    }
+	Series Series::arctan2(const Series &lhs, const Series &rhs) {
+		arma::vec x = lhs.values();
+		arma::vec y = rhs.values();
+		arma::vec result = numc::arctan2(x, y);
+		return Series(result, lhs.index());
+	}
 
-    Series Series::concat(const Series &lhs, const Series &rhs) {
-        arma::vec expanded_values = lhs.values();
-        arma::vec expanded_indices = lhs.index();
-        expanded_values.insert_rows(lhs.values().size(), rhs.values());
-        expanded_indices.insert_rows(lhs.values().size(), rhs.index());
-        return Series(expanded_values, expanded_indices);
-    }
+	Series Series::concat(const Series &lhs, const Series &rhs) {
+		arma::vec expanded_values = lhs.values();
+		arma::vec expanded_indices = lhs.index();
+		expanded_values.insert_rows(lhs.values().size(), rhs.values());
+		expanded_indices.insert_rows(lhs.values().size(), rhs.index());
+		return Series(expanded_values, expanded_indices);
+	}
 
-    /**
-     * Add support for pretty printing of a Series object.
-     * @param os the output stream that will be written to
-     * @param ts the Series instance to output
-     * @return the ostream for further piping
-     */
-    std::ostream &operator<<(std::ostream &os, const Series &ts) {
+	/**
+	 * Add support for pretty printing of a Series object.
+	 * @param os the output stream that will be written to
+	 * @param ts the Series instance to output
+	 * @return the ostream for further piping
+	 */
+	std::ostream &operator<<(std::ostream &os, const Series &ts) {
 
-        if(ts.size() >= 5){
-            os << "Series:\nindices\n" << ts.head(5).index() << "values\n" << ts.head(5).values();
-            os << "\n....\n";
-            os << "Series:\nindices\n" << ts.tail(5).index() << "values\n" << ts.tail(5).values();
-            return os;
-        } else {
-            return os << "Series:\nindices\n" << ts.index() << "values\n" << ts.values();
-        }
-    }
+		if(ts.size() >= 5){
+			os << "Series:\nindices\n" << ts.head(5).index() << "values\n" << ts.head(5).values();
+			os << "\n....\n";
+			os << "Series:\nindices\n" << ts.tail(5).index() << "values\n" << ts.tail(5).values();
+			return os;
+		} else {
+			return os << "Series:\nindices\n" << ts.index() << "values\n" << ts.values();
+		}
+	}
 }; // polars

--- a/src/cpp/polars/Series.cpp
+++ b/src/cpp/polars/Series.cpp
@@ -25,808 +25,808 @@
 namespace polars {
 
 
-	using SeriesMask = polars::SeriesMask;
+    using SeriesMask = polars::SeriesMask;
 
-	Series::Series() = default;
+    Series::Series() = default;
 
 
 // todo; check for 1-D series & that the lengths match
-	Series::Series(const arma::vec &v, const arma::vec &t) : t(t), v(v) {
-		//assert(t.n_cols == 1 && v.n_cols == 1);
-		//assert(t.n_rows == v.n_rows);
-	};
+    Series::Series(const arma::vec &v, const arma::vec &t) : t(t), v(v) {
+        //assert(t.n_cols == 1 && v.n_cols == 1);
+        //assert(t.n_rows == v.n_rows);
+    };
 
-	/**
-	 * Converting constructor - this takes a SeriesMask and creates a Series from it.
-	 *
-	 * This is intentionally implicit (not marked explicit) so that a function expecting a Series can be passed a
-	 * SeriesMask and it will be automatically converted since this is a loss-less process.
-	 */
-	Series::Series(const SeriesMask &sm) : t(sm.index()), v(arma::conv_to<arma::vec>::from(sm.values())) {}
+    /**
+     * Converting constructor - this takes a SeriesMask and creates a Series from it.
+     *
+     * This is intentionally implicit (not marked explicit) so that a function expecting a Series can be passed a
+     * SeriesMask and it will be automatically converted since this is a loss-less process.
+     */
+    Series::Series(const SeriesMask &sm) : t(sm.index()), v(arma::conv_to<arma::vec>::from(sm.values())) {}
 
-	Series Series::from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v) {
-		return Series(arma::conv_to<arma::vec>::from(v_v), arma::conv_to<arma::vec>::from(t_v));
-	}
+    Series Series::from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v) {
+        return Series(arma::conv_to<arma::vec>::from(v_v), arma::conv_to<arma::vec>::from(t_v));
+    }
 
-	Series Series::from_map(const std::map<double, double> &iv_map) {
-		arma::vec index(iv_map.size());
-		arma::vec values(iv_map.size());
-		int i = 0;
-		for (auto& pair : iv_map) {
-			index[i] = pair.first;
-			values[i] = pair.second;
-			++i;
-		}
-		return {values, index};
-	}
+    Series Series::from_map(const std::map<double, double> &iv_map) {
+        arma::vec index(iv_map.size());
+        arma::vec values(iv_map.size());
+        int i = 0;
+        for (auto& pair : iv_map) {
+            index[i] = pair.first;
+            values[i] = pair.second;
+            ++i;
+        }
+        return {values, index};
+    }
 
 
 // Series [op] int methods
-	SeriesMask Series::operator==(const int rhs) const {
-		arma::vec rhs_vec = arma::ones(this->size()) * rhs;
-		arma::vec abs_diff = arma::abs(values() - rhs_vec);
-		// We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
-		double threshold = 1E-50;
-		return SeriesMask(abs_diff < threshold, index());
-	}
+    SeriesMask Series::operator==(const int rhs) const {
+        arma::vec rhs_vec = arma::ones(this->size()) * rhs;
+        arma::vec abs_diff = arma::abs(values() - rhs_vec);
+        // We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
+        double threshold = 1E-50;
+        return SeriesMask(abs_diff < threshold, index());
+    }
 
 
-	SeriesMask Series::operator!=(const int rhs) const {  // TODO implement as negation of operator==
-		arma::vec rhs_vec = arma::ones(this->size()) * rhs;
-		arma::vec abs_diff = arma::abs(values() - rhs_vec);
-		// We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
-		double threshold = 1E-50;
-		return SeriesMask(abs_diff > threshold, index());
-	}
+    SeriesMask Series::operator!=(const int rhs) const {  // TODO implement as negation of operator==
+        arma::vec rhs_vec = arma::ones(this->size()) * rhs;
+        arma::vec abs_diff = arma::abs(values() - rhs_vec);
+        // We can't use a large difference test like .1 despite the rhs is an int since the lhs is double so could be close.
+        double threshold = 1E-50;
+        return SeriesMask(abs_diff > threshold, index());
+    }
 
 
-	// Series [op] Series methods
-	SeriesMask Series::operator==(const Series &rhs) const {
-		// TODO: make this fast enough to always check at runtime
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return SeriesMask(values() == rhs.values(), index());
-	}
+    // Series [op] Series methods
+    SeriesMask Series::operator==(const Series &rhs) const {
+        // TODO: make this fast enough to always check at runtime
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return SeriesMask(values() == rhs.values(), index());
+    }
 
 
-	SeriesMask Series::operator!=(const Series &rhs) const {
-		// TODO: make this fast enough to always check at runtime
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return SeriesMask(values() != rhs.values(), index());
-	}
+    SeriesMask Series::operator!=(const Series &rhs) const {
+        // TODO: make this fast enough to always check at runtime
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return SeriesMask(values() != rhs.values(), index());
+    }
 
 
-	SeriesMask Series::operator>(const Series &rhs) const {
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return SeriesMask(values() > rhs.values(), index());
-	}
+    SeriesMask Series::operator>(const Series &rhs) const {
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return SeriesMask(values() > rhs.values(), index());
+    }
 
 
-	SeriesMask Series::operator<(const Series &rhs) const {
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return polars::SeriesMask(values() < rhs.values(), index());
-	}
+    SeriesMask Series::operator<(const Series &rhs) const {
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return polars::SeriesMask(values() < rhs.values(), index());
+    }
 
 
-	Series Series::operator+(const Series &rhs) const {
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return polars::Series(values() + rhs.values(), index());
-	}
+    Series Series::operator+(const Series &rhs) const {
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return polars::Series(values() + rhs.values(), index());
+    }
 
 
-	Series Series::operator-(const Series &rhs) const {
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return polars::Series(values() - rhs.values(), index());
-	}
+    Series Series::operator-(const Series &rhs) const {
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return polars::Series(values() - rhs.values(), index());
+    }
 
 
-	Series Series::operator*(const Series &rhs) const {
-		//assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
-		return polars::Series(values() % rhs.values(), index());
-	}
+    Series Series::operator*(const Series &rhs) const {
+        //assert(!arma::any(index() != rhs.index()));  // Use not any != to handle empty array case
+        return polars::Series(values() % rhs.values(), index());
+    }
 
 
 // Series [op] double methods
-	SeriesMask Series::operator>(const double &rhs) const {
-		return SeriesMask(values() > (arma::ones(size()) * rhs), index());
-	}
+    SeriesMask Series::operator>(const double &rhs) const {
+        return SeriesMask(values() > (arma::ones(size()) * rhs), index());
+    }
 
-	SeriesMask Series::operator<(const double &rhs) const {
-		return SeriesMask(values() < (arma::ones(size()) * rhs), index());
-	}
+    SeriesMask Series::operator<(const double &rhs) const {
+        return SeriesMask(values() < (arma::ones(size()) * rhs), index());
+    }
 
-	SeriesMask Series::operator>=(const double &rhs) const {
-		return SeriesMask(values() >= (arma::ones(size()) * rhs), index());
-	}
+    SeriesMask Series::operator>=(const double &rhs) const {
+        return SeriesMask(values() >= (arma::ones(size()) * rhs), index());
+    }
 
-	SeriesMask Series::operator<=(const double &rhs) const {
-		return SeriesMask(values() <= (arma::ones(size()) * rhs), index());
-	}
+    SeriesMask Series::operator<=(const double &rhs) const {
+        return SeriesMask(values() <= (arma::ones(size()) * rhs), index());
+    }
 
-	Series Series::operator+(const double &rhs) const {
-		return Series(values() + rhs, index());
-	}
-
-
-	Series Series::operator-(const double &rhs) const {
-		return Series(values() - rhs, index());
-	}
+    Series Series::operator+(const double &rhs) const {
+        return Series(values() + rhs, index());
+    }
 
 
-	Series Series::operator*(const double &rhs) const {
-		return Series(values() * rhs, index());
-	}
+    Series Series::operator-(const double &rhs) const {
+        return Series(values() - rhs, index());
+    }
 
 
-// todo; do we need a flavor that *doesn't* take account of NANs?
-	bool Series::equals(const Series &rhs) const {
-		if ((index().n_rows != rhs.index().n_rows)) return false;
-		if ((index().n_cols != rhs.index().n_cols)) return false;
-		if (!polars::numc::equal_handling_nans(values(), rhs.values())) return false;
-		if (any(index() != rhs.index())) return false;
-		return true;
-	}
+    Series Series::operator*(const double &rhs) const {
+        return Series(values() * rhs, index());
+    }
 
 
 // todo; do we need a flavor that *doesn't* take account of NANs?
-	bool Series::almost_equals(const Series &rhs) const {
-		if ((index().n_rows != rhs.index().n_rows)) return false;
-		if ((index().n_cols != rhs.index().n_cols)) return false;
-		if (!polars::numc::almost_equal_handling_nans(values(), rhs.values())) return false;
-		if (any(index() != rhs.index())) return false;
-		return true;
-	}
+    bool Series::equals(const Series &rhs) const {
+        if ((index().n_rows != rhs.index().n_rows)) return false;
+        if ((index().n_cols != rhs.index().n_cols)) return false;
+        if (!polars::numc::equal_handling_nans(values(), rhs.values())) return false;
+        if (any(index() != rhs.index())) return false;
+        return true;
+    }
+
+
+// todo; do we need a flavor that *doesn't* take account of NANs?
+    bool Series::almost_equals(const Series &rhs) const {
+        if ((index().n_rows != rhs.index().n_rows)) return false;
+        if ((index().n_cols != rhs.index().n_cols)) return false;
+        if (!polars::numc::almost_equal_handling_nans(values(), rhs.values())) return false;
+        if (any(index() != rhs.index())) return false;
+        return true;
+    }
 
 // Location.
 
-	Series Series::iloc(int from, int to, int step) const {
+    Series Series::iloc(int from, int to, int step) const {
 
-		if(empty() || (from == to)){
-			return Series();
-		}
+        if(empty() || (from == to)){
+            return Series();
+        }
 
-		arma::uvec pos;
-		int effective_from;
-		int effective_to;
+        arma::uvec pos;
+        int effective_from;
+        int effective_to;
 
-		if(from < 0){
-			effective_from = values().size() + from;
-		} else {
-			effective_from = from;
-		}
+        if(from < 0){
+            effective_from = values().size() + from;
+        } else {
+            effective_from = from;
+        }
 
-		if(to < 0){
-			effective_to = values().size() + to - 1;
-		} else if(to == 0) {
-			effective_to = to;
-		} else {
-			effective_to = to - 1;
-		}
+        if(to < 0){
+            effective_to = values().size() + to - 1;
+        } else if(to == 0) {
+            effective_to = to;
+        } else {
+            effective_to = to - 1;
+        }
 
-		pos = arma::regspace<arma::uvec>(effective_from,  step,  effective_to);
+        pos = arma::regspace<arma::uvec>(effective_from,  step,  effective_to);
 
-		if(pos.size() > size()){
-			pos = pos.subvec(0, size() - 1);
-		}
+        if(pos.size() > size()){
+            pos = pos.subvec(0, size() - 1);
+        }
 
-		return Series(values().elem(pos),index().elem(pos));
-	}
+        return Series(values().elem(pos),index().elem(pos));
+    }
 
-	// TODO: Add slicing logic of the form .iloc(int start, int stop, int step=1) so it can be called like ser.iloc(0, -10).
-	Series Series::iloc(const arma::uvec &pos) const {
-		return Series(values().elem(pos), index().elem(pos));
-	}
+    // TODO: Add slicing logic of the form .iloc(int start, int stop, int step=1) so it can be called like ser.iloc(0, -10).
+    Series Series::iloc(const arma::uvec &pos) const {
+        return Series(values().elem(pos), index().elem(pos));
+    }
 
 
-	double Series::iloc(arma::uword pos) const {
-		arma::vec val = values().elem(arma::uvec{pos});
-		return val[0];
-	}
+    double Series::iloc(arma::uword pos) const {
+        arma::vec val = values().elem(arma::uvec{pos});
+        return val[0];
+    }
 
 // by label of indices
-	Series Series::loc(const arma::vec &index_labels) const {
-
-		std::vector<int> indices;
-
-		for (int j = 0; j < index_labels.n_elem; j++) {
-
-			arma::uvec idx = arma::find(index() == index_labels[j]);
-
-			if (!idx.empty()) {
-				indices.push_back(idx[0]);
-			}
-		}
-
-		if (indices.empty()) {
-			return Series();
-		} else {
-			arma::uvec indices_v = arma::conv_to<arma::uvec>::from(indices);
-			return Series(values().elem(indices_v), index().elem(indices_v));
-		}
-	}
-
-	Series Series::loc(arma::uword pos) const {
-		arma::uvec idx = arma::find(index() == pos);
-
-		if (!idx.empty()) {
-			return Series(values(), index()).iloc(idx);
-		} else {
-			return Series();
-		}
-	}
-
-	Series Series::where(const SeriesMask &condition, double other) const {
-		arma::vec result = values();
-		result.elem(find((!condition).values())).fill(other);
-		return Series(result, index());
-	}
-
-
-	Series Series::diff() const {
-
-		arma::uword resultSize = values().size();
-
-		arma::vec resultv(resultSize);
-
-		double previousValue = NAN;
-		for (arma::uword idx = 0; idx < resultSize; idx++) {
-			resultv[idx] = values()[idx] - previousValue;
-			previousValue = values()[idx];
-		}
-
-		return Series(resultv, index());
-	}
-
-
-	Series Series::abs() const {
-		return Series(arma::abs(values()), index());
-	}
-
-	double Series::quantile(double q) const {
-		return polars::numc::quantile(values(), q);
-	}
-
-	Series Series::fillna(double value) const {
-		arma::vec vals = values();
-		vals.replace(arma::datum::nan, value);
-		return Series(vals, index());
-	}
-
-	Series Series::dropna() const {
-		// Get indices of finite elements
-		arma::uvec indices = arma::sort(arma::join_cols(
-				arma::find_finite(values()),
-				arma::find(arma::abs(values()) == arma::datum::inf))
-		);
-		return Series(values().elem(indices), index().elem(indices));
-	}
-
-
-	arma::vec calculate_window_weights(
-			polars::WindowProcessor::WindowType win_type,
-			arma::uword windowSize
-	) {
-		switch (win_type) {
-			case (polars::WindowProcessor::WindowType::none):
-				return arma::ones(windowSize);
-			case (polars::WindowProcessor::WindowType::triang):
-				return polars::numc::triang(windowSize);
-			default:
-				return arma::ones(windowSize);
-		}
-	}
-
-	// TODO: This method needs to be re-factored.
-	arma::vec _ewm_correction(const arma::vec &results, const arma::vec &vals,
-							  polars::WindowProcessor::WindowType win_type) {
-		/* Method that shifts result from rolling average with exp window so it yields correct normalisation and allows usage
-		 * of rolling method hereby implemented.
-		 * This matches pandas ewm for its default case */
-
-		arma::uvec res_fin = arma::find_finite(results);
-
-		if (results.empty() || res_fin.empty()){
-			arma::vec effective_results(vals.size());
-			effective_results.fill(NAN);
-			return effective_results;
-		}
-
-		if (win_type == polars::WindowProcessor::WindowType::expn) {
-			// Correction to match pandas ewm - shift by one.
-			arma::vec effective_results = results;
-			arma::vec results_ewm;
-			int missing_initial_nans =  0;
-
-			// Check if it was a case of originally front NANs - no added padding
-			arma::uvec finite_values_idx = arma::find_finite(vals);
-			if(finite_values_idx[0] != 0){
-				// we had originally some NANs.
-				missing_initial_nans = finite_values_idx[0];
-			}
-
-			arma::vec effective_vals = vals.subvec(missing_initial_nans, vals.size() - 1);
-
-			// For the cases in which window_size < size we need to correct
-			if( (results.size() > effective_vals.size())){
-				effective_results = effective_results.elem( arma::find_finite(effective_results) );
-				effective_results = effective_results.head(effective_vals.size());
-			}
-
-			if ( effective_results.at(0) == effective_vals[0] ){
-				// difference of 1 for center = False.
-				results_ewm = effective_results;
-			} else {
-				results_ewm.copy_size(effective_results) ;
-				results_ewm.at(0) = vals[0];
-
-				for (int j = 1; j < results_ewm.n_elem; j++) {
-					results_ewm[j] = effective_results[j - 1];
-				}
-			}
-
-			if(missing_initial_nans > 0){
-				auto added_nans = vals.size() - results_ewm.size();
-				arma::vec pn(added_nans);
-				pn.fill(NAN);
-				return arma::join_cols(pn, results_ewm);
-			} else {
-				return results_ewm;
-			}
-
-		} else {
-			return results;
-		}
-	}
-
-	// TODO: Combine cases here with those in input for exponential case.
-	polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input){
-		// This is required because of relative size of window size vs array size.
-
-		if(input.size() == 1){
-			return input;
-		}
-
-		auto n = window_size / 2;
-		if(input.size() % 2 == 0){ n = n - 1; };
-
-		// Get index delta
-		auto ts = input.index();
-		double delta = std::ceil(std::abs(ts(1) -  ts(0)));
-
-		// Vector with n nans
-		arma::vec multi_nan(n);
-		multi_nan.fill(NAN);
-
-		// Vector with single nan
-		arma::vec single_nan(1);
-		single_nan.fill(NAN);
-
-		// Base case is padding goes to the right
-		arma::vec new_input = arma::join_cols(input.values(),  multi_nan);
-
-		auto start_idx = ts(0);
-		auto end_idx = ts(ts.size()-1) + n * delta;
-		auto effective_size = n + input.size();
-
-		if (center == false){
-
-			if( window_size > input.size() + 1 ){
-				new_input = arma::join_cols(multi_nan, input.values());
-				start_idx = start_idx - n * delta;
-				end_idx = end_idx - n * delta;
-			} else if (n == 1) {
-				new_input = arma::join_cols(single_nan, arma::join_cols(single_nan, input.values()));
-				start_idx = start_idx - 2 * delta;
-				end_idx = end_idx - delta;
-
-				effective_size = effective_size + 1;
-			} else if (n == 2) {
-				new_input = arma::join_cols(single_nan, arma::join_cols(input.values(), single_nan));
-				start_idx = start_idx - delta;
-				end_idx = end_idx - delta;
-			}
-		}
-
-		arma::vec new_timestamps = arma::linspace(start_idx, end_idx, effective_size);
-
-		return Series(new_input, new_timestamps);
-	}
-
-	// TODO: Refactor this method and combine with window_size_correction since similar logic
-	polars::Series _ewm_input_correction(const polars::Series &input){
-		// only gets called when window_size < input.size() and we have win_type = expn
-		Series new_input = input;
-
-		if(input.empty() || input.dropna().empty()){
-			return input;
-		}
-
-		// remove front NANs
-		if(std::isnan(input.values()(0))){
-			arma::uvec finite_input_idx = arma::find_finite(input.values());
-			auto number_of_nans = finite_input_idx(0);
-			new_input = input.iloc(number_of_nans, input.size());
-		}
-
-		arma::vec v(new_input.size());
-		v.fill(NAN);
-		arma::vec new_values = arma::join_cols(v, new_input.values());
-
-		// Get new timestamps
-		auto ts = new_input.index();
-		auto delta = std::ceil(std::abs(input.index()(1) -  input.index()(0))); // use original input
-
-		auto new_index_0 = ts(0) - new_input.size() * delta;
-		arma::vec new_timestamps = arma::linspace(new_index_0, ts(ts.size()-1), 2 * new_input.size());
-
-		return Series(new_values, new_timestamps);
-	}
-
-	std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx) {
-
-		arma::uword centerOffset = round(((float) windowSize - 1) / 2.0);
-
-		arma::sword leftIdx = centerIdx - centerOffset;
-		arma::sword rightIdx = centerIdx - centerOffset + windowSize - 1;
-		arma::sword weightLeftIdx = 0;
-		arma::sword weightRightIdx = windowSize - 1;
-
-		if (symmetric) {
-			// This option works for odd windows only.
-			if (leftIdx < 0) {
-				arma::sword left_err = leftIdx;
-				arma::sword right_err = windowSize - 1 - centerIdx - centerOffset;
-
-				weightLeftIdx = weightLeftIdx - left_err;
-				weightRightIdx = weightRightIdx - right_err;
-
-				rightIdx = rightIdx - right_err;
-				leftIdx = leftIdx - left_err;
-			}
-			if (rightIdx >= inputSize) {
-				arma::sword r_clipped = rightIdx - inputSize;
-
-				arma::sword left_err = -r_clipped - 1;
-				arma::sword right_err = rightIdx - (inputSize - 1);
-
-				weightLeftIdx = weightLeftIdx - left_err;
-				weightRightIdx = weightRightIdx - right_err;
-
-				leftIdx = leftIdx - left_err;
-				rightIdx = rightIdx - right_err;
-			}
-
-		} else {
-			if (leftIdx < 0) {
-				arma::sword left_err = leftIdx;
-
-				weightLeftIdx = weightLeftIdx - left_err;
-				leftIdx = leftIdx - left_err;
-			}
-
-			if (rightIdx >= inputSize) {
-				arma::sword right_err = rightIdx - (inputSize - 1);
-
-				weightRightIdx = weightRightIdx - right_err;
-				rightIdx = rightIdx - right_err;
-			}
-		}
-		return {leftIdx, rightIdx, weightLeftIdx, weightRightIdx};
-	}
-
-	Series _align_to_left(Series input, int windowSize) {
-		// Only need to realign for center=False and windowSize > input.size()
-		arma::vec moved_values = arma::zeros(windowSize - 1) * NAN;
-
-		auto ceil_half = std::ceil((windowSize-1.0)/2.0);
-		auto rolling_start_idx = ceil_half;
-		auto rolling_end_idx = input.size() - (windowSize - ceil_half);
-
-		arma::vec rolling_values = input.values().subvec(rolling_start_idx, rolling_end_idx);
-		moved_values.insert_rows(windowSize-1, rolling_values);
-		return polars::Series(moved_values, input.index());
-
-	};
-
-	Series
-	Series::ewm(SeriesSize windowSize, SeriesSize minPeriods, bool center, double alpha) const {
-		arma::vec input_values = v;
-		arma::vec input_idx = t;
-
-		Series padded_input = _ewm_input_correction(*this);
-		input_values = padded_input.values();
-		input_idx = padded_input.index();
-
-		// Set window size to be the same as the size of the array
-		windowSize = this->size();
-
-		if (minPeriods == 0) {
-			minPeriods = windowSize;
-		}
-
-		arma::vec resultv(arma::size(input_values));
-
-		for (arma::uword centerIdx = 0; centerIdx < input_idx.size(); centerIdx++) {
-			int leftIdx, rightIdx, weightLeftIdx, weightRightIdx;
-			std::tie(
-					leftIdx, rightIdx, weightLeftIdx, weightRightIdx
-			) = _get_interval_edges(windowSize, input_idx.size(), false, centerIdx);
-			arma::vec values = input_values.subvec(leftIdx, rightIdx);
-
-			// Define weights vector required for specific windows
-			arma::vec exponential_weights = reverse(
-					polars::numc::exponential(windowSize, -1. / log(1 - alpha), false, 0)
-			);
-			arma::vec weights(arma::size(values));
-			weights = exponential_weights.subvec(weightLeftIdx, weightRightIdx);
-
-			const Series subSeries = Series(values, input_idx.subvec(leftIdx, rightIdx));
-
-			if (subSeries.finiteSize() >= minPeriods) {
-				resultv(centerIdx) = polars::ExpMean().processWindow(subSeries, weights);
-			} else {
-				resultv(centerIdx) = polars::ExpMean().defaultValue();
-			}
-		}
-
-		Series result = Series(
-				polars::_ewm_correction(resultv, v, polars::WindowProcessor::WindowType::expn), t);
-
-		if(size() > 0 & windowSize > size()){
-			return Series(result.values().head(size()), t);
-		} else {
-			return result;
-		}
-	}
+    Series Series::loc(const arma::vec &index_labels) const {
+
+        std::vector<int> indices;
+
+        for (int j = 0; j < index_labels.n_elem; j++) {
+
+            arma::uvec idx = arma::find(index() == index_labels[j]);
+
+            if (!idx.empty()) {
+                indices.push_back(idx[0]);
+            }
+        }
+
+        if (indices.empty()) {
+            return Series();
+        } else {
+            arma::uvec indices_v = arma::conv_to<arma::uvec>::from(indices);
+            return Series(values().elem(indices_v), index().elem(indices_v));
+        }
+    }
+
+    Series Series::loc(arma::uword pos) const {
+        arma::uvec idx = arma::find(index() == pos);
+
+        if (!idx.empty()) {
+            return Series(values(), index()).iloc(idx);
+        } else {
+            return Series();
+        }
+    }
+
+    Series Series::where(const SeriesMask &condition, double other) const {
+        arma::vec result = values();
+        result.elem(find((!condition).values())).fill(other);
+        return Series(result, index());
+    }
+
+
+    Series Series::diff() const {
+
+        arma::uword resultSize = values().size();
+
+        arma::vec resultv(resultSize);
+
+        double previousValue = NAN;
+        for (arma::uword idx = 0; idx < resultSize; idx++) {
+            resultv[idx] = values()[idx] - previousValue;
+            previousValue = values()[idx];
+        }
+
+        return Series(resultv, index());
+    }
+
+
+    Series Series::abs() const {
+        return Series(arma::abs(values()), index());
+    }
+
+    double Series::quantile(double q) const {
+        return polars::numc::quantile(values(), q);
+    }
+
+    Series Series::fillna(double value) const {
+        arma::vec vals = values();
+        vals.replace(arma::datum::nan, value);
+        return Series(vals, index());
+    }
+
+    Series Series::dropna() const {
+        // Get indices of finite elements
+        arma::uvec indices = arma::sort(arma::join_cols(
+                arma::find_finite(values()),
+                arma::find(arma::abs(values()) == arma::datum::inf))
+        );
+        return Series(values().elem(indices), index().elem(indices));
+    }
+
+
+    arma::vec calculate_window_weights(
+            polars::WindowProcessor::WindowType win_type,
+            arma::uword windowSize
+    ) {
+        switch (win_type) {
+            case (polars::WindowProcessor::WindowType::none):
+                return arma::ones(windowSize);
+            case (polars::WindowProcessor::WindowType::triang):
+                return polars::numc::triang(windowSize);
+            default:
+                return arma::ones(windowSize);
+        }
+    }
+
+    // TODO: This method needs to be re-factored.
+    arma::vec _ewm_correction(const arma::vec &results, const arma::vec &vals,
+                              polars::WindowProcessor::WindowType win_type) {
+        /* Method that shifts result from rolling average with exp window so it yields correct normalisation and allows usage
+         * of rolling method hereby implemented.
+         * This matches pandas ewm for its default case */
+
+        arma::uvec res_fin = arma::find_finite(results);
+
+        if (results.empty() || res_fin.empty()){
+            arma::vec effective_results(vals.size());
+            effective_results.fill(NAN);
+            return effective_results;
+        }
+
+        if (win_type == polars::WindowProcessor::WindowType::expn) {
+            // Correction to match pandas ewm - shift by one.
+            arma::vec effective_results = results;
+            arma::vec results_ewm;
+            int missing_initial_nans =  0;
+
+            // Check if it was a case of originally front NANs - no added padding
+            arma::uvec finite_values_idx = arma::find_finite(vals);
+            if(finite_values_idx[0] != 0){
+                // we had originally some NANs.
+                missing_initial_nans = finite_values_idx[0];
+            }
+
+            arma::vec effective_vals = vals.subvec(missing_initial_nans, vals.size() - 1);
+
+            // For the cases in which window_size < size we need to correct
+            if( (results.size() > effective_vals.size())){
+                effective_results = effective_results.elem( arma::find_finite(effective_results) );
+                effective_results = effective_results.head(effective_vals.size());
+            }
+
+            if ( effective_results.at(0) == effective_vals[0] ){
+                // difference of 1 for center = False.
+                results_ewm = effective_results;
+            } else {
+                results_ewm.copy_size(effective_results) ;
+                results_ewm.at(0) = vals[0];
+
+                for (int j = 1; j < results_ewm.n_elem; j++) {
+                    results_ewm[j] = effective_results[j - 1];
+                }
+            }
+
+            if(missing_initial_nans > 0){
+                auto added_nans = vals.size() - results_ewm.size();
+                arma::vec pn(added_nans);
+                pn.fill(NAN);
+                return arma::join_cols(pn, results_ewm);
+            } else {
+                return results_ewm;
+            }
+
+        } else {
+            return results;
+        }
+    }
+
+    // TODO: Combine cases here with those in input for exponential case.
+    polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input){
+        // This is required because of relative size of window size vs array size.
+
+        if(input.size() == 1){
+            return input;
+        }
+
+        auto n = window_size / 2;
+        if(input.size() % 2 == 0){ n = n - 1; };
+
+        // Get index delta
+        auto ts = input.index();
+        double delta = std::ceil(std::abs(ts(1) -  ts(0)));
+
+        // Vector with n nans
+        arma::vec multi_nan(n);
+        multi_nan.fill(NAN);
+
+        // Vector with single nan
+        arma::vec single_nan(1);
+        single_nan.fill(NAN);
+
+        // Base case is padding goes to the right
+        arma::vec new_input = arma::join_cols(input.values(),  multi_nan);
+
+        auto start_idx = ts(0);
+        auto end_idx = ts(ts.size()-1) + n * delta;
+        auto effective_size = n + input.size();
+
+        if (center == false){
+
+            if( window_size > input.size() + 1 ){
+                new_input = arma::join_cols(multi_nan, input.values());
+                start_idx = start_idx - n * delta;
+                end_idx = end_idx - n * delta;
+            } else if (n == 1) {
+                new_input = arma::join_cols(single_nan, arma::join_cols(single_nan, input.values()));
+                start_idx = start_idx - 2 * delta;
+                end_idx = end_idx - delta;
+
+                effective_size = effective_size + 1;
+            } else if (n == 2) {
+                new_input = arma::join_cols(single_nan, arma::join_cols(input.values(), single_nan));
+                start_idx = start_idx - delta;
+                end_idx = end_idx - delta;
+            }
+        }
+
+        arma::vec new_timestamps = arma::linspace(start_idx, end_idx, effective_size);
+
+        return Series(new_input, new_timestamps);
+    }
+
+    // TODO: Refactor this method and combine with window_size_correction since similar logic
+    polars::Series _ewm_input_correction(const polars::Series &input){
+        // only gets called when window_size < input.size() and we have win_type = expn
+        Series new_input = input;
+
+        if(input.empty() || input.dropna().empty()){
+            return input;
+        }
+
+        // remove front NANs
+        if(std::isnan(input.values()(0))){
+            arma::uvec finite_input_idx = arma::find_finite(input.values());
+            auto number_of_nans = finite_input_idx(0);
+            new_input = input.iloc(number_of_nans, input.size());
+        }
+
+        arma::vec v(new_input.size());
+        v.fill(NAN);
+        arma::vec new_values = arma::join_cols(v, new_input.values());
+
+        // Get new timestamps
+        auto ts = new_input.index();
+        auto delta = std::ceil(std::abs(input.index()(1) -  input.index()(0))); // use original input
+
+        auto new_index_0 = ts(0) - new_input.size() * delta;
+        arma::vec new_timestamps = arma::linspace(new_index_0, ts(ts.size()-1), 2 * new_input.size());
+
+        return Series(new_values, new_timestamps);
+    }
+
+    std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx) {
+
+        arma::uword centerOffset = round(((float) windowSize - 1) / 2.0);
+
+        arma::sword leftIdx = centerIdx - centerOffset;
+        arma::sword rightIdx = centerIdx - centerOffset + windowSize - 1;
+        arma::sword weightLeftIdx = 0;
+        arma::sword weightRightIdx = windowSize - 1;
+
+        if (symmetric) {
+            // This option works for odd windows only.
+            if (leftIdx < 0) {
+                arma::sword left_err = leftIdx;
+                arma::sword right_err = windowSize - 1 - centerIdx - centerOffset;
+
+                weightLeftIdx = weightLeftIdx - left_err;
+                weightRightIdx = weightRightIdx - right_err;
+
+                rightIdx = rightIdx - right_err;
+                leftIdx = leftIdx - left_err;
+            }
+            if (rightIdx >= inputSize) {
+                arma::sword r_clipped = rightIdx - inputSize;
+
+                arma::sword left_err = -r_clipped - 1;
+                arma::sword right_err = rightIdx - (inputSize - 1);
+
+                weightLeftIdx = weightLeftIdx - left_err;
+                weightRightIdx = weightRightIdx - right_err;
+
+                leftIdx = leftIdx - left_err;
+                rightIdx = rightIdx - right_err;
+            }
+
+        } else {
+            if (leftIdx < 0) {
+                arma::sword left_err = leftIdx;
+
+                weightLeftIdx = weightLeftIdx - left_err;
+                leftIdx = leftIdx - left_err;
+            }
+
+            if (rightIdx >= inputSize) {
+                arma::sword right_err = rightIdx - (inputSize - 1);
+
+                weightRightIdx = weightRightIdx - right_err;
+                rightIdx = rightIdx - right_err;
+            }
+        }
+        return {leftIdx, rightIdx, weightLeftIdx, weightRightIdx};
+    }
+
+    Series _align_to_left(Series input, int windowSize) {
+        // Only need to realign for center=False and windowSize > input.size()
+        arma::vec moved_values = arma::zeros(windowSize - 1) * NAN;
+
+        auto ceil_half = std::ceil((windowSize-1.0)/2.0);
+        auto rolling_start_idx = ceil_half;
+        auto rolling_end_idx = input.size() - (windowSize - ceil_half);
+
+        arma::vec rolling_values = input.values().subvec(rolling_start_idx, rolling_end_idx);
+        moved_values.insert_rows(windowSize-1, rolling_values);
+        return polars::Series(moved_values, input.index());
+
+    };
+
+    Series
+    Series::ewm(SeriesSize windowSize, SeriesSize minPeriods, bool center, double alpha) const {
+        arma::vec input_values = v;
+        arma::vec input_idx = t;
+
+        Series padded_input = _ewm_input_correction(*this);
+        input_values = padded_input.values();
+        input_idx = padded_input.index();
+
+        // Set window size to be the same as the size of the array
+        windowSize = this->size();
+
+        if (minPeriods == 0) {
+            minPeriods = windowSize;
+        }
+
+        arma::vec resultv(arma::size(input_values));
+
+        for (arma::uword centerIdx = 0; centerIdx < input_idx.size(); centerIdx++) {
+            int leftIdx, rightIdx, weightLeftIdx, weightRightIdx;
+            std::tie(
+                    leftIdx, rightIdx, weightLeftIdx, weightRightIdx
+            ) = _get_interval_edges(windowSize, input_idx.size(), false, centerIdx);
+            arma::vec values = input_values.subvec(leftIdx, rightIdx);
+
+            // Define weights vector required for specific windows
+            arma::vec exponential_weights = reverse(
+                    polars::numc::exponential(windowSize, -1. / log(1 - alpha), false, 0)
+            );
+            arma::vec weights(arma::size(values));
+            weights = exponential_weights.subvec(weightLeftIdx, weightRightIdx);
+
+            const Series subSeries = Series(values, input_idx.subvec(leftIdx, rightIdx));
+
+            if (subSeries.finiteSize() >= minPeriods) {
+                resultv(centerIdx) = polars::ExpMean().processWindow(subSeries, weights);
+            } else {
+                resultv(centerIdx) = polars::ExpMean().defaultValue();
+            }
+        }
+
+        Series result = Series(
+                polars::_ewm_correction(resultv, v, polars::WindowProcessor::WindowType::expn), t);
+
+        if(size() > 0 & windowSize > size()){
+            return Series(result.values().head(size()), t);
+        } else {
+            return result;
+        }
+    }
 
 // todo; allow passing in transformation function rather than WindowProcessor.
-	Series
-	Series::rolling(SeriesSize windowSize, const polars::WindowProcessor &processor, SeriesSize minPeriods,
-					bool center, bool symmetric, polars::WindowProcessor::WindowType win_type) const {
+    Series
+    Series::rolling(SeriesSize windowSize, const polars::WindowProcessor &processor, SeriesSize minPeriods,
+                    bool center, bool symmetric, polars::WindowProcessor::WindowType win_type) const {
 
-		//assert(center); // todo; implement center:false
-		//assert(windowSize > 0);
-		//assert(windowSize % 2 == 0); // TODO: Make symmetric = true work for even windows. See tests for reference.
-		arma::vec input_values = v;
-		arma::vec input_idx = t;
+        //assert(center); // todo; implement center:false
+        //assert(windowSize > 0);
+        //assert(windowSize % 2 == 0); // TODO: Make symmetric = true work for even windows. See tests for reference.
+        arma::vec input_values = v;
+        arma::vec input_idx = t;
 
-		if((size() > 0 && windowSize > size())) {
-			// This deals with issues of alignment that arises with non linear windows.
-			Series padded_input = _window_size_correction(windowSize, center, *this);
-			input_values = padded_input.values();
-			input_idx = padded_input.index();
-		}
+        if((size() > 0 && windowSize > size())) {
+            // This deals with issues of alignment that arises with non linear windows.
+            Series padded_input = _window_size_correction(windowSize, center, *this);
+            input_values = padded_input.values();
+            input_idx = padded_input.index();
+        }
 
-		if (minPeriods == 0) {
-			minPeriods = windowSize;
-		}
+        if (minPeriods == 0) {
+            minPeriods = windowSize;
+        }
 
-		arma::vec resultv(arma::size(input_values));
+        arma::vec resultv(arma::size(input_values));
 
-		// roll a window [left,right], of up to size windowSize, centered on centerIdx, and hand to processor if there are minPeriods finite values.
-		for (arma::uword centerIdx = 0; centerIdx < input_idx.size(); centerIdx++) {
-			int leftIdx, rightIdx, weightLeftIdx, weightRightIdx;
-			std::tie(
-					leftIdx, rightIdx, weightLeftIdx, weightRightIdx
-			) = _get_interval_edges(windowSize, input_idx.size(), symmetric, centerIdx);
-			arma::vec values = input_values.subvec(leftIdx, rightIdx);
-			// Define weights vector required for specific windows
-			arma::vec weights(arma::size(values));
-			weights = polars::calculate_window_weights(win_type, windowSize).subvec(weightLeftIdx, weightRightIdx);
+        // roll a window [left,right], of up to size windowSize, centered on centerIdx, and hand to processor if there are minPeriods finite values.
+        for (arma::uword centerIdx = 0; centerIdx < input_idx.size(); centerIdx++) {
+            int leftIdx, rightIdx, weightLeftIdx, weightRightIdx;
+            std::tie(
+                    leftIdx, rightIdx, weightLeftIdx, weightRightIdx
+            ) = _get_interval_edges(windowSize, input_idx.size(), symmetric, centerIdx);
+            arma::vec values = input_values.subvec(leftIdx, rightIdx);
+            // Define weights vector required for specific windows
+            arma::vec weights(arma::size(values));
+            weights = polars::calculate_window_weights(win_type, windowSize).subvec(weightLeftIdx, weightRightIdx);
 
-			const Series subSeries = Series(values, input_idx.subvec(leftIdx, rightIdx));
+            const Series subSeries = Series(values, input_idx.subvec(leftIdx, rightIdx));
 
-			if ( subSeries.finiteSize() >= minPeriods) {
-				resultv(centerIdx) = processor.processWindow(subSeries, weights);
-			} else {
-				resultv(centerIdx) = processor.defaultValue();
-			}
-		}
+            if ( subSeries.finiteSize() >= minPeriods) {
+                resultv(centerIdx) = processor.processWindow(subSeries, weights);
+            } else {
+                resultv(centerIdx) = processor.defaultValue();
+            }
+        }
 
-		Series result = Series(resultv, t);
+        Series result = Series(resultv, t);
 
-		if(size() > 0 & windowSize > size()){
-			return Series(result.values().head(size()), t);
-		} else {
-			if( (center == true) || (windowSize <= 2) ){
-				return result;
-			} else {
-				return _align_to_left(result, windowSize);
-			}
-		}
-	}
+        if(size() > 0 & windowSize > size()){
+            return Series(result.values().head(size()), t);
+        } else {
+            if( (center == true) || (windowSize <= 2) ){
+                return result;
+            } else {
+                return _align_to_left(result, windowSize);
+            }
+        }
+    }
 
-	Window Series::rolling(SeriesSize windowSize,
-						   SeriesSize minPeriods,
-						   bool center,
-						   bool symmetric,
-						   polars::WindowProcessor::WindowType win_type) const {
-		return Window((*this), windowSize, minPeriods, center, symmetric, win_type);
-	};
+    Window Series::rolling(SeriesSize windowSize,
+                           SeriesSize minPeriods,
+                           bool center,
+                           bool symmetric,
+                           polars::WindowProcessor::WindowType win_type) const {
+        return Window((*this), windowSize, minPeriods, center, symmetric, win_type);
+    };
 
-	Rolling Series::rolling(SeriesSize windowSize,
-							SeriesSize minPeriods,
-							bool center,
-							bool symmetric) const {
-		return Rolling((*this), windowSize, minPeriods, center, symmetric);
-	};
-
-
-	Series Series::clip(double lower_limit, double upper_limit) const {
-		SeriesMask upper = SeriesMask(values() < upper_limit, index());
-		SeriesMask lower = SeriesMask(values() > lower_limit, index());
-		return Series(values(), index()).where(upper, upper_limit).where(lower, lower_limit);
-	};
+    Rolling Series::rolling(SeriesSize windowSize,
+                            SeriesSize minPeriods,
+                            bool center,
+                            bool symmetric) const {
+        return Rolling((*this), windowSize, minPeriods, center, symmetric);
+    };
 
 
-	Series Series::pow(double power) const {
-		return Series(arma::pow(values(), power), index());
-	}
+    Series Series::clip(double lower_limit, double upper_limit) const {
+        SeriesMask upper = SeriesMask(values() < upper_limit, index());
+        SeriesMask lower = SeriesMask(values() > lower_limit, index());
+        return Series(values(), index()).where(upper, upper_limit).where(lower, lower_limit);
+    };
 
 
-	int Series::count() const {
-		return finiteSize();
-	}
+    Series Series::pow(double power) const {
+        return Series(arma::pow(values(), power), index());
+    }
 
 
-	double Series::sum() const {
-		arma::vec finites = finiteValues();
-		if (finites.size() == 0) {
-			return NAN;
-		} else {
-			return arma::sum(finites);
-		}
-	}
+    int Series::count() const {
+        return finiteSize();
+    }
 
 
-	double Series::mean() const {
-		arma::vec finites = finiteValues();
-		if (finites.size() == 0) {
-			return NAN;
-		} else {
-			return arma::mean(finites);
-		}
-	}
+    double Series::sum() const {
+        arma::vec finites = finiteValues();
+        if (finites.size() == 0) {
+            return NAN;
+        } else {
+            return arma::sum(finites);
+        }
+    }
 
 
-	double Series::std(int ddof) const {
-		arma::vec finites = finiteValues();
-		if (ddof < 0) {
-			ddof = 0;
-		}
-		auto n = finites.size();
-		if (n <= ddof) {
-			return NAN;
-		} else {
-			auto dev = (*this) - this->mean();
-			auto squared_deviation = dev.pow(2);
-			return std::pow(squared_deviation.sum() / (n - ddof), 0.5);
-		}
-	}
+    double Series::mean() const {
+        arma::vec finites = finiteValues();
+        if (finites.size() == 0) {
+            return NAN;
+        } else {
+            return arma::mean(finites);
+        }
+    }
 
 
-	Series::SeriesSize Series::size() const {
-		//assert(index().size() == values().size());
-		return index().size();
-	}
+    double Series::std(int ddof) const {
+        arma::vec finites = finiteValues();
+        if (ddof < 0) {
+            ddof = 0;
+        }
+        auto n = finites.size();
+        if (n <= ddof) {
+            return NAN;
+        } else {
+            auto dev = (*this) - this->mean();
+            auto squared_deviation = dev.pow(2);
+            return std::pow(squared_deviation.sum() / (n - ddof), 0.5);
+        }
+    }
 
 
-	arma::vec Series::finiteValues() const {
-		return values().elem(find_finite(values()));
-	}
+    Series::SeriesSize Series::size() const {
+        //assert(index().size() == values().size());
+        return index().size();
+    }
 
 
-	Series::SeriesSize Series::finiteSize() const {
-		//assert(index().size() == values().size());
-		return finiteValues().size();
-	}
+    arma::vec Series::finiteValues() const {
+        return values().elem(find_finite(values()));
+    }
+
+
+    Series::SeriesSize Series::finiteSize() const {
+        //assert(index().size() == values().size());
+        return finiteValues().size();
+    }
 
 
 // done this way so default copy / assignment works.
 // todo; make copies of indices share memory as they are const?
-	const arma::vec Series::index() const {
-		return t;
-	}
+    const arma::vec Series::index() const {
+        return t;
+    }
 
 
-	const arma::vec Series::values() const {
-		return v;
-	}
+    const arma::vec Series::values() const {
+        return v;
+    }
 
 
-	bool Series::equal(const Series &lhs, const Series &rhs) {
-		return lhs.equals(rhs);
-	}
+    bool Series::equal(const Series &lhs, const Series &rhs) {
+        return lhs.equals(rhs);
+    }
 
 
-	bool Series::almost_equal(const Series &lhs, const Series &rhs) {
-		return lhs.almost_equals(rhs);
-	}
+    bool Series::almost_equal(const Series &lhs, const Series &rhs) {
+        return lhs.almost_equals(rhs);
+    }
 
 
-	bool Series::not_equal(const Series &lhs, const Series &rhs) {
-		return !lhs.equals(rhs);
-	}
+    bool Series::not_equal(const Series &lhs, const Series &rhs) {
+        return !lhs.equals(rhs);
+    }
 
-	Series Series::apply(double (*f)(double)) const {
-		arma::vec vals = values();
-		vals.transform([=](double val) { return (f(val)); });
-		return Series(vals, index());
-	}
+    Series Series::apply(double (*f)(double)) const {
+        arma::vec vals = values();
+        vals.transform([=](double val) { return (f(val)); });
+        return Series(vals, index());
+    }
 
-	Series Series::index_as_series() const {
-		return Series(index(), index());
-	}
+    Series Series::index_as_series() const {
+        return Series(index(), index());
+    }
 
-	std::map<double, double> Series::to_map() const {
+    std::map<double, double> Series::to_map() const {
 
-		std::map<double, double> m;
-		// put pairs into map
-		for (int i = 0; i < size(); i++) {
-			m.insert(std::make_pair(index()[i], values()[i]));
-		}
+        std::map<double, double> m;
+        // put pairs into map
+        for (int i = 0; i < size(); i++) {
+            m.insert(std::make_pair(index()[i], values()[i]));
+        }
 
-		return m;
-	}
+        return m;
+    }
 
-	bool Series::empty() const {
-		return (index().is_empty() & values().is_empty());
-	}
+    bool Series::empty() const {
+        return (index().is_empty() & values().is_empty());
+    }
 
-	// TODO: Modify head once iloc has been refactored to accept slicing logic.
-	Series Series::head(int n) const  {
-		Series ser(values(), index());
-		if(n >= ser.size()){
-			return ser;
-		} else {
-			arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(0, n));
-			return ser.iloc(indices);
-		}
-	}
+    // TODO: Modify head once iloc has been refactored to accept slicing logic.
+    Series Series::head(int n) const  {
+        Series ser(values(), index());
+        if(n >= ser.size()){
+            return ser;
+        } else {
+            arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(0, n));
+            return ser.iloc(indices);
+        }
+    }
 
-	// TODO: Modify tail once iloc has been refactored to accept slicing logic.
-	Series Series::tail(int n) const  {
+    // TODO: Modify tail once iloc has been refactored to accept slicing logic.
+    Series Series::tail(int n) const  {
 
-		Series ser(values(), index());
+        Series ser(values(), index());
 
-		if(n >= ser.size()){
-			return ser;
-		} else {
-			arma::uword l = ser.size() - n;
-			arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(l, ser.size()));
-			return ser.iloc(indices);
-		}
-	}
+        if(n >= ser.size()){
+            return ser;
+        } else {
+            arma::uword l = ser.size() - n;
+            arma::uvec indices = arma::conv_to<arma::uvec>::from(polars::numc::arange(l, ser.size()));
+            return ser.iloc(indices);
+        }
+    }
 
-	Series Series::arctan2(const Series &lhs, const Series &rhs) {
-		arma::vec x = lhs.values();
-		arma::vec y = rhs.values();
-		arma::vec result = numc::arctan2(x, y);
-		return Series(result, lhs.index());
-	}
+    Series Series::arctan2(const Series &lhs, const Series &rhs) {
+        arma::vec x = lhs.values();
+        arma::vec y = rhs.values();
+        arma::vec result = numc::arctan2(x, y);
+        return Series(result, lhs.index());
+    }
 
-	Series Series::concat(const Series &lhs, const Series &rhs) {
-		arma::vec expanded_values = lhs.values();
-		arma::vec expanded_indices = lhs.index();
-		expanded_values.insert_rows(lhs.values().size(), rhs.values());
-		expanded_indices.insert_rows(lhs.values().size(), rhs.index());
-		return Series(expanded_values, expanded_indices);
-	}
+    Series Series::concat(const Series &lhs, const Series &rhs) {
+        arma::vec expanded_values = lhs.values();
+        arma::vec expanded_indices = lhs.index();
+        expanded_values.insert_rows(lhs.values().size(), rhs.values());
+        expanded_indices.insert_rows(lhs.values().size(), rhs.index());
+        return Series(expanded_values, expanded_indices);
+    }
 
-	/**
-	 * Add support for pretty printing of a Series object.
-	 * @param os the output stream that will be written to
-	 * @param ts the Series instance to output
-	 * @return the ostream for further piping
-	 */
-	std::ostream &operator<<(std::ostream &os, const Series &ts) {
+    /**
+     * Add support for pretty printing of a Series object.
+     * @param os the output stream that will be written to
+     * @param ts the Series instance to output
+     * @return the ostream for further piping
+     */
+    std::ostream &operator<<(std::ostream &os, const Series &ts) {
 
-		if(ts.size() >= 5){
-			os << "Series:\nindices\n" << ts.head(5).index() << "values\n" << ts.head(5).values();
-			os << "\n....\n";
-			os << "Series:\nindices\n" << ts.tail(5).index() << "values\n" << ts.tail(5).values();
-			return os;
-		} else {
-			return os << "Series:\nindices\n" << ts.index() << "values\n" << ts.values();
-		}
-	}
+        if(ts.size() >= 5){
+            os << "Series:\nindices\n" << ts.head(5).index() << "values\n" << ts.head(5).values();
+            os << "\n....\n";
+            os << "Series:\nindices\n" << ts.tail(5).index() << "values\n" << ts.tail(5).values();
+            return os;
+        } else {
+            return os << "Series:\nindices\n" << ts.index() << "values\n" << ts.values();
+        }
+    }
 }; // polars

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -16,163 +16,163 @@
 
 
 namespace polars {
-	class SeriesMask;
+    class SeriesMask;
 
 
-	class Series {
-	public:
-		typedef arma::uword SeriesSize;
+    class Series {
+    public:
+        typedef arma::uword SeriesSize;
 
-		Series();
+        Series();
 
-		Series(const arma::vec &v, const arma::vec &t);
+        Series(const arma::vec &v, const arma::vec &t);
 
-		Series(const SeriesMask &sm);
+        Series(const SeriesMask &sm);
 
-		static Series from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v);
+        static Series from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v);
 
-		static Series from_map(const std::map<double, double> &iv_map);
+        static Series from_map(const std::map<double, double> &iv_map);
 
-		SeriesMask operator==(const int rhs) const;
+        SeriesMask operator==(const int rhs) const;
 
-		SeriesMask operator!=(const int rhs) const;
+        SeriesMask operator!=(const int rhs) const;
 
-		Series operator+(const double &rhs) const;
+        Series operator+(const double &rhs) const;
 
-		Series operator-(const double &rhs) const;
+        Series operator-(const double &rhs) const;
 
-		Series operator*(const double &rhs) const;
+        Series operator*(const double &rhs) const;
 
-		SeriesMask operator>(const double &rhs) const;
+        SeriesMask operator>(const double &rhs) const;
 
-		SeriesMask operator<(const double &rhs) const;
+        SeriesMask operator<(const double &rhs) const;
 
-		SeriesMask operator>=(const double &rhs) const;
+        SeriesMask operator>=(const double &rhs) const;
 
-		SeriesMask operator<=(const double &rhs) const;
+        SeriesMask operator<=(const double &rhs) const;
 
-		SeriesMask operator==(const Series &rhs) const;  // TODO test for floating point stability
+        SeriesMask operator==(const Series &rhs) const;  // TODO test for floating point stability
 
-		SeriesMask operator!=(const Series &rhs) const;  // TODO test for floating point stability
+        SeriesMask operator!=(const Series &rhs) const;  // TODO test for floating point stability
 
-		SeriesMask operator>(const Series &rhs) const;
+        SeriesMask operator>(const Series &rhs) const;
 
-		SeriesMask operator<(const Series &rhs) const;
+        SeriesMask operator<(const Series &rhs) const;
 
-		Series operator+(const Series &rhs) const;
+        Series operator+(const Series &rhs) const;
 
-		Series operator-(const Series &rhs) const;
+        Series operator-(const Series &rhs) const;
 
-		Series operator*(const Series &rhs) const;
+        Series operator*(const Series &rhs) const;
 
-		bool equals(const Series &rhs) const;
+        bool equals(const Series &rhs) const;
 
-		bool almost_equals(const Series &rhs) const;
+        bool almost_equals(const Series &rhs) const;
 
-		Series iloc(const arma::uvec &pos) const;
+        Series iloc(const arma::uvec &pos) const;
 
-		double iloc(arma::uword pos) const;
+        double iloc(arma::uword pos) const;
 
-		Series iloc(int from, int to, int step = 1) const;
+        Series iloc(int from, int to, int step = 1) const;
 
-		Series loc(const arma::vec &index_labels) const;
+        Series loc(const arma::vec &index_labels) const;
 
-		Series loc(arma::uword) const;
+        Series loc(arma::uword) const;
 
-		Series where(const SeriesMask &condition, double other = NAN) const;
+        Series where(const SeriesMask &condition, double other = NAN) const;
 
-		Series diff() const;
+        Series diff() const;
 
-		Series abs() const;
+        Series abs() const;
 
-		double quantile(double q = 0.5) const;
+        double quantile(double q = 0.5) const;
 
-		Series fillna(double value = 0.) const;
+        Series fillna(double value = 0.) const;
 
-		Series dropna() const;
+        Series dropna() const;
 
-		Series clip(double lower_limit, double upper_limit) const;
+        Series clip(double lower_limit, double upper_limit) const;
 
-		Series pow(double power) const;
+        Series pow(double power) const;
 
-		Series rolling(SeriesSize windowSize,
-					   const WindowProcessor &processor,
-					   SeriesSize minPeriods = 0, /* 0 treated as windowSize */
-					   bool center = true,
-					   bool symmetric = false,
-					   WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
+        Series rolling(SeriesSize windowSize,
+                       const WindowProcessor &processor,
+                       SeriesSize minPeriods = 0, /* 0 treated as windowSize */
+                       bool center = true,
+                       bool symmetric = false,
+                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
 
-		Series ewm(SeriesSize windowSize,
-				   SeriesSize minPeriods,
-				   bool center = true,
-				   double alpha = -1) const;
+        Series ewm(SeriesSize windowSize,
+                   SeriesSize minPeriods,
+                   bool center = true,
+                   double alpha = -1) const;
 
-		Window rolling(SeriesSize windowSize,
-					   SeriesSize minPeriods, /* 0 treated as windowSize */
-					   bool center,
-					   bool symmetric,
-					   polars::WindowProcessor::WindowType win_type) const;
+        Window rolling(SeriesSize windowSize,
+                       SeriesSize minPeriods, /* 0 treated as windowSize */
+                       bool center,
+                       bool symmetric,
+                       polars::WindowProcessor::WindowType win_type) const;
 
-		Rolling rolling(SeriesSize windowSize,
-						SeriesSize minPeriods = 0, /* 0 treated as windowSize */
-						bool center = true,
-						bool symmetric = false) const;
+        Rolling rolling(SeriesSize windowSize,
+                        SeriesSize minPeriods = 0, /* 0 treated as windowSize */
+                        bool center = true,
+                        bool symmetric = false) const;
 
-		Series apply(double (*f)(double)) const;
+        Series apply(double (*f)(double)) const;
 
-		int count() const;
+        int count() const;
 
-		double sum() const;
+        double sum() const;
 
-		double mean() const;
+        double mean() const;
 
-		double std(int ddof=1) const;
+        double std(int ddof=1) const;
 
-		SeriesSize size() const;
+        SeriesSize size() const;
 
-		arma::vec finiteValues() const;
+        arma::vec finiteValues() const;
 
-		SeriesSize finiteSize() const;
+        SeriesSize finiteSize() const;
 
-		// done this way so default copy / assignment works.
-		// todo; make copies of indices share memory as they are const?
-		const arma::vec index() const;
+        // done this way so default copy / assignment works.
+        // todo; make copies of indices share memory as they are const?
+        const arma::vec index() const;
 
-		const arma::vec values() const;
+        const arma::vec values() const;
 
-		static bool equal(const Series &lhs, const Series &rhs);
+        static bool equal(const Series &lhs, const Series &rhs);
 
-		static bool almost_equal(const Series &lhs, const Series &rhs);
+        static bool almost_equal(const Series &lhs, const Series &rhs);
 
-		static bool not_equal(const Series &lhs, const Series &rhs);
+        static bool not_equal(const Series &lhs, const Series &rhs);
 
-		Series index_as_series() const;
+        Series index_as_series() const;
 
-		std::map<double, double> to_map() const;
+        std::map<double, double> to_map() const;
 
-		bool empty() const;
+        bool empty() const;
 
-		Series head(int n=5) const;
+        Series head(int n=5) const;
 
-		Series tail(int n=5) const;
+        Series tail(int n=5) const;
 
-		static Series arctan2(const Series &lhs, const Series &rhs);
+        static Series arctan2(const Series &lhs, const Series &rhs);
 
-		static Series concat(const Series &lhs, const Series &rhs);
+        static Series concat(const Series &lhs, const Series &rhs);
 
-	protected:
-		arma::vec t;
-		arma::vec v;
-	};
+    protected:
+        arma::vec t;
+        arma::vec v;
+    };
 
-	std::ostream &operator<<(std::ostream &os, const Series &ts);
+    std::ostream &operator<<(std::ostream &os, const Series &ts);
 
 
-	polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
-	polars::Series _ewm_input_correction(const polars::Series &input);
+    polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
+    polars::Series _ewm_input_correction(const polars::Series &input);
 
-	std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
-	polars::Series _align_to_left(Series input, int windowSize);
+    std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
+    polars::Series _align_to_left(Series input, int windowSize);
 }
 
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -100,15 +100,18 @@ namespace polars {
                        SeriesSize minPeriods = 0, /* 0 treated as windowSize */
                        bool center = true,
                        bool symmetric = false,
-                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none,
-                       double alpha = -1) const;
+                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
+
+		Series ewm(SeriesSize windowSize,
+				SeriesSize minPeriods,
+				bool center = true,
+				double alpha = -1) const;
 
         Window rolling(SeriesSize windowSize,
                        SeriesSize minPeriods, /* 0 treated as windowSize */
                        bool center,
                        bool symmetric,
-                       polars::WindowProcessor::WindowType win_type,
-                       double alpha = -1) const;
+                       polars::WindowProcessor::WindowType win_type) const;
 
         Rolling rolling(SeriesSize windowSize,
                         SeriesSize minPeriods = 0, /* 0 treated as windowSize */
@@ -167,6 +170,8 @@ namespace polars {
 
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
     polars::Series _ewm_input_correction(const polars::Series &input);
+
+	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool center, bool symmetric, int centerIdx);
 }
 
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -171,7 +171,8 @@ namespace polars {
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
     polars::Series _ewm_input_correction(const polars::Series &input);
 
-	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool center, bool symmetric, int centerIdx);
+	std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
+	polars::Series _align_to_left(Series input, int windowSize);
 }
 
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -103,6 +103,11 @@ namespace polars {
                        WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none,
                        double alpha = -1) const;
 
+		Series ewm(SeriesSize windowSize,
+				SeriesSize minPeriods,
+				bool center = true,
+				double alpha = -1) const;
+
         Window rolling(SeriesSize windowSize,
                        SeriesSize minPeriods, /* 0 treated as windowSize */
                        bool center,
@@ -167,6 +172,8 @@ namespace polars {
 
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
     polars::Series _ewm_input_correction(const polars::Series &input);
+
+	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
 }
 
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -16,162 +16,163 @@
 
 
 namespace polars {
-    class SeriesMask;
+	class SeriesMask;
 
 
-    class Series {
-    public:
-        typedef arma::uword SeriesSize;
+	class Series {
+	public:
+		typedef arma::uword SeriesSize;
 
-        Series();
+		Series();
 
-        Series(const arma::vec &v, const arma::vec &t);
+		Series(const arma::vec &v, const arma::vec &t);
 
-        Series(const SeriesMask &sm);
+		Series(const SeriesMask &sm);
 
-        static Series from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v);
+		static Series from_vect(const std::vector<double> &t_v, const std::vector<double> &v_v);
 
-        static Series from_map(const std::map<double, double> &iv_map);
+		static Series from_map(const std::map<double, double> &iv_map);
 
-        SeriesMask operator==(const int rhs) const;
+		SeriesMask operator==(const int rhs) const;
 
-        SeriesMask operator!=(const int rhs) const;
+		SeriesMask operator!=(const int rhs) const;
 
-        Series operator+(const double &rhs) const;
+		Series operator+(const double &rhs) const;
 
-        Series operator-(const double &rhs) const;
+		Series operator-(const double &rhs) const;
 
-        Series operator*(const double &rhs) const;
+		Series operator*(const double &rhs) const;
 
-        SeriesMask operator>(const double &rhs) const;
+		SeriesMask operator>(const double &rhs) const;
 
-        SeriesMask operator<(const double &rhs) const;
+		SeriesMask operator<(const double &rhs) const;
 
-        SeriesMask operator>=(const double &rhs) const;
+		SeriesMask operator>=(const double &rhs) const;
 
-        SeriesMask operator<=(const double &rhs) const;
+		SeriesMask operator<=(const double &rhs) const;
 
-        SeriesMask operator==(const Series &rhs) const;  // TODO test for floating point stability
+		SeriesMask operator==(const Series &rhs) const;  // TODO test for floating point stability
 
-        SeriesMask operator!=(const Series &rhs) const;  // TODO test for floating point stability
+		SeriesMask operator!=(const Series &rhs) const;  // TODO test for floating point stability
 
-        SeriesMask operator>(const Series &rhs) const;
+		SeriesMask operator>(const Series &rhs) const;
 
-        SeriesMask operator<(const Series &rhs) const;
+		SeriesMask operator<(const Series &rhs) const;
 
-        Series operator+(const Series &rhs) const;
+		Series operator+(const Series &rhs) const;
 
-        Series operator-(const Series &rhs) const;
+		Series operator-(const Series &rhs) const;
 
-        Series operator*(const Series &rhs) const;
+		Series operator*(const Series &rhs) const;
 
-        bool equals(const Series &rhs) const;
+		bool equals(const Series &rhs) const;
 
-        bool almost_equals(const Series &rhs) const;
+		bool almost_equals(const Series &rhs) const;
 
-        Series iloc(const arma::uvec &pos) const;
+		Series iloc(const arma::uvec &pos) const;
 
-        double iloc(arma::uword pos) const;
+		double iloc(arma::uword pos) const;
 
-        Series iloc(int from, int to, int step = 1) const;
+		Series iloc(int from, int to, int step = 1) const;
 
-        Series loc(const arma::vec &index_labels) const;
+		Series loc(const arma::vec &index_labels) const;
 
-        Series loc(arma::uword) const;
+		Series loc(arma::uword) const;
 
-        Series where(const SeriesMask &condition, double other = NAN) const;
+		Series where(const SeriesMask &condition, double other = NAN) const;
 
-        Series diff() const;
+		Series diff() const;
 
-        Series abs() const;
+		Series abs() const;
 
-        double quantile(double q = 0.5) const;
+		double quantile(double q = 0.5) const;
 
-        Series fillna(double value = 0.) const;
+		Series fillna(double value = 0.) const;
 
-        Series dropna() const;
+		Series dropna() const;
 
-        Series clip(double lower_limit, double upper_limit) const;
+		Series clip(double lower_limit, double upper_limit) const;
 
-        Series pow(double power) const;
+		Series pow(double power) const;
 
-        Series rolling(SeriesSize windowSize,
-                       const WindowProcessor &processor,
-                       SeriesSize minPeriods = 0, /* 0 treated as windowSize */
-                       bool center = true,
-                       bool symmetric = false,
-                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
+		Series rolling(SeriesSize windowSize,
+					   const WindowProcessor &processor,
+					   SeriesSize minPeriods = 0, /* 0 treated as windowSize */
+					   bool center = true,
+					   bool symmetric = false,
+					   WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
 
 		Series ewm(SeriesSize windowSize,
-				SeriesSize minPeriods,
-				bool center = true,
-				double alpha = -1) const;
+				   SeriesSize minPeriods,
+				   bool center = true,
+				   double alpha = -1) const;
 
-        Window rolling(SeriesSize windowSize,
-                       SeriesSize minPeriods, /* 0 treated as windowSize */
-                       bool center,
-                       bool symmetric,
-                       polars::WindowProcessor::WindowType win_type) const;
+		Window rolling(SeriesSize windowSize,
+					   SeriesSize minPeriods, /* 0 treated as windowSize */
+					   bool center,
+					   bool symmetric,
+					   polars::WindowProcessor::WindowType win_type) const;
 
-        Rolling rolling(SeriesSize windowSize,
-                        SeriesSize minPeriods = 0, /* 0 treated as windowSize */
-                        bool center = true,
-                        bool symmetric = false) const;
+		Rolling rolling(SeriesSize windowSize,
+						SeriesSize minPeriods = 0, /* 0 treated as windowSize */
+						bool center = true,
+						bool symmetric = false) const;
 
-        Series apply(double (*f)(double)) const;
+		Series apply(double (*f)(double)) const;
 
-        int count() const;
+		int count() const;
 
-        double sum() const;
+		double sum() const;
 
-        double mean() const;
+		double mean() const;
 
-        double std(int ddof=1) const;
+		double std(int ddof=1) const;
 
-        SeriesSize size() const;
+		SeriesSize size() const;
 
-        arma::vec finiteValues() const;
+		arma::vec finiteValues() const;
 
-        SeriesSize finiteSize() const;
+		SeriesSize finiteSize() const;
 
-        // done this way so default copy / assignment works.
-        // todo; make copies of indices share memory as they are const?
-        const arma::vec index() const;
+		// done this way so default copy / assignment works.
+		// todo; make copies of indices share memory as they are const?
+		const arma::vec index() const;
 
-        const arma::vec values() const;
+		const arma::vec values() const;
 
-        static bool equal(const Series &lhs, const Series &rhs);
+		static bool equal(const Series &lhs, const Series &rhs);
 
-        static bool almost_equal(const Series &lhs, const Series &rhs);
+		static bool almost_equal(const Series &lhs, const Series &rhs);
 
-        static bool not_equal(const Series &lhs, const Series &rhs);
+		static bool not_equal(const Series &lhs, const Series &rhs);
 
-        Series index_as_series() const;
+		Series index_as_series() const;
 
-        std::map<double, double> to_map() const;
+		std::map<double, double> to_map() const;
 
-        bool empty() const;
+		bool empty() const;
 
-        Series head(int n=5) const;
+		Series head(int n=5) const;
 
-        Series tail(int n=5) const;
+		Series tail(int n=5) const;
 
-        static Series arctan2(const Series &lhs, const Series &rhs);
+		static Series arctan2(const Series &lhs, const Series &rhs);
 
-        static Series concat(const Series &lhs, const Series &rhs);
+		static Series concat(const Series &lhs, const Series &rhs);
 
-    protected:
-        arma::vec t;
-        arma::vec v;
-    };
+	protected:
+		arma::vec t;
+		arma::vec v;
+	};
 
-    std::ostream &operator<<(std::ostream &os, const Series &ts);
+	std::ostream &operator<<(std::ostream &os, const Series &ts);
 
 
-    polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
-    polars::Series _ewm_input_correction(const polars::Series &input);
+	polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
+	polars::Series _ewm_input_correction(const polars::Series &input);
 
-	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool center, bool symmetric, int centerIdx);
+	std::tuple<int, int, int, int> _get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
+	polars::Series _align_to_left(Series input, int windowSize);
 }
 
 

--- a/src/cpp/polars/Series.h
+++ b/src/cpp/polars/Series.h
@@ -100,8 +100,7 @@ namespace polars {
                        SeriesSize minPeriods = 0, /* 0 treated as windowSize */
                        bool center = true,
                        bool symmetric = false,
-                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none,
-                       double alpha = -1) const;
+                       WindowProcessor::WindowType win_type = WindowProcessor::WindowType::none) const;
 
 		Series ewm(SeriesSize windowSize,
 				SeriesSize minPeriods,
@@ -112,8 +111,7 @@ namespace polars {
                        SeriesSize minPeriods, /* 0 treated as windowSize */
                        bool center,
                        bool symmetric,
-                       polars::WindowProcessor::WindowType win_type,
-                       double alpha = -1) const;
+                       polars::WindowProcessor::WindowType win_type) const;
 
         Rolling rolling(SeriesSize windowSize,
                         SeriesSize minPeriods = 0, /* 0 treated as windowSize */
@@ -173,7 +171,7 @@ namespace polars {
     polars::Series _window_size_correction(int window_size, bool center, const polars::Series &input);
     polars::Series _ewm_input_correction(const polars::Series &input);
 
-	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool symmetric, int centerIdx);
+	std::tuple<int, int, int, int> get_interval_edges(int windowSize, int inputSize, bool center, bool symmetric, int centerIdx);
 }
 
 

--- a/src/cpp/polars/WindowProcessor.cpp
+++ b/src/cpp/polars/WindowProcessor.cpp
@@ -117,15 +117,11 @@ namespace polars {
     }
 
     Series Window::mean() {
-        if (win_type_ == WindowProcessor::WindowType::expn) {
-            return ts_.rolling(windowSize_, ExpMean(), minPeriods_, center_, symmetric_, win_type_, alpha_);
-        } else {
-            return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_, win_type_, alpha_);
-        }
+        return ts_.rolling(windowSize_, Mean(), minPeriods_, center_, symmetric_, win_type_);
     }
 
     Series Window::sum() {
-        return ts_.rolling(windowSize_, Sum(), minPeriods_, center_, symmetric_, win_type_, alpha_);
+        return ts_.rolling(windowSize_, Sum(), minPeriods_, center_, symmetric_, win_type_);
     }
 
 } // polars

--- a/src/cpp/polars/WindowProcessor.h
+++ b/src/cpp/polars/WindowProcessor.h
@@ -113,8 +113,7 @@ namespace polars {
         double default_value = NAN;
     };
 
-    arma::vec calculate_window_weights(polars::WindowProcessor::WindowType win_type, arma::uword windowSize,
-                                       double alpha = -1);
+    arma::vec calculate_window_weights(polars::WindowProcessor::WindowType win_type, arma::uword windowSize);
 
     arma::vec _ewm_correction(const arma::vec &results, const arma::vec &v0, polars::WindowProcessor::WindowType win_type);
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -10,853 +10,853 @@
 
 
 namespace SeriesTests {
-	using namespace polars;
-
-	TEST(Series, constructors) {
-		EXPECT_PRED2(Series::equal, Series(SeriesMask()), Series())
-							<< "Expect constructing with empty SeriesMask is the same as empty constructor";
-		EXPECT_PRED2(Series::equal, Series(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
-							<< "Expect true becomes 1 and false becomes 0";
-
-		auto foo = [](Series s){return s;};
-		EXPECT_PRED2(Series::equal, foo(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
-							<< "Expect implicit conversion from SeriesMask to Series is possible so that you can pass a SeriesMask to a function expecting a Series";
-
-	}
-
-	TEST(Series, from_map) {
-		EXPECT_PRED2(Series::equal, Series::from_map({}), Series());
-
-		EXPECT_PRED2(Series::equal, Series::from_map({{1, 3},
-													  {2, 4}}), Series({3, 4}, {1, 2}));
-
-	}
-
-	TEST(Series, equal) {
-		EXPECT_PRED2(Series::equal, Series(), Series()) << "Expect " << "empty Series' match";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-					 Series(arma::vec({3, 4}), arma::vec({1, 2})));
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({NAN}), arma::vec({1})),
-					 Series(arma::vec({NAN}), arma::vec({1})))
-							<< "Expect " << "simple indices with NAN match";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
-					 Series(arma::vec({}), arma::vec({})))
-							<< "Expect " << "empty indices match";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})),
-					 Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})))
-							<< "Expect " << "longer indices with NANs match";
-	}
-
-	TEST(Series, not_equal) {
-		EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-					 Series(arma::vec({1, 2}), arma::vec({1, 2})))
-							<< "Expect " << "index match does not imply Series match";
-
-		EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-					 Series(arma::vec({3, 4}), arma::vec({3, 4})))
-							<< "Expect " << "values match does not imply Series match";
-
-		EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-					 Series(arma::vec({1, 2}), arma::vec({3, 4})))
-							<< "Expect " << "swapping index and values results in no match" << "";
-	}
-
-	TEST(Series, where) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), 17),
-				Series({17, 4}, {1, 2})
-		) << "Expect " << "simple where()  to select correctly";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), NAN),
-				Series({NAN, 4}, {1, 2})
-		) << "Expect " << ".where(..., NAN) to not set everything to NAN";
-	}
-
-	TEST(Series, DiffTest) {
-		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).diff(),
-					 Series(arma::vec({NAN, 1}), arma::vec({1, 2})))
-							<< "Expect " << "simple diff() fixture result to be correct" << "";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({4, 3}), arma::vec({1, 2})).diff(),
-					 Series(arma::vec({NAN, -1}), arma::vec({1, 2})))
-							<< "Expect " << "simple diff() fixture result to be correct" << "";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({3}), arma::vec({1})).diff(),
-					 Series(arma::vec({NAN}), arma::vec({1})))
-							<< "Expect " << "simple diff() fixture result to be correct" << "";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).diff(),
-					 Series(arma::vec({}), arma::vec({})))
-							<< "Expect " << "exmpty indices diff() fixture result to be correct" << "";
-	}
-
-	TEST(Series, abs) {
-		EXPECT_PRED2(Series::equal,
-					 Series(arma::vec({0, 3, 4, -2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})).abs(),
-					 Series(arma::vec({0, 3, 4, 2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})))
-							<< "Expect " << "negative values to be positive and rest to remain the same.";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
-					 Series(arma::vec({}), arma::vec({})))
-							<< "Expect " << "empty Series .abs() to return empty Series";
-	}
-
-	TEST(Series, PowTest) {
-		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(2),
-					 Series(arma::vec({9, 16}), arma::vec({1, 2})))
-							<< "Expect " << "simple pow() fixture result to be correct" << "";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(3),
-					 Series(arma::vec({27, 64}), arma::vec({1, 2})))
-							<< "Expect " << "simple pow() fixture result to be correct" << "";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({9}), arma::vec({1})).pow(0.5),
-					 Series(arma::vec({3}), arma::vec({1})))
-							<< "Expect " << "simple pow() fixture result to be correct" << "";
-
-		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
-					 Series(arma::vec({}), arma::vec({})))
-							<< "Expect " << "empty indices pow() fixture result to be correct" << "";
-	}
-
-	TEST(Series, fillna) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 0, 3, 0, 5}, {1, 2, 3, 4, 5}),
-				Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna()
-		) << "Expect " << "replace NANs with zeros";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 1, 3, 1, 5}, {1, 2, 3, 4, 5}),
-				Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna(1.)
-		) << "Expect " << "replace NANs with ones";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).fillna()
-		) << "Expect " << " remains the same as no NANs";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series(),
-				Series().fillna()
-		) << "Expect " << " empty array";
-
-	}
-
-	TEST(Series, dropna) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 3, 5}, {1, 3, 5}),
-				Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).dropna()
-		) << "Expect " << "drop NANs so indices only contains finite elements";
+    using namespace polars;
+
+    TEST(Series, constructors) {
+        EXPECT_PRED2(Series::equal, Series(SeriesMask()), Series())
+                            << "Expect constructing with empty SeriesMask is the same as empty constructor";
+        EXPECT_PRED2(Series::equal, Series(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
+                            << "Expect true becomes 1 and false becomes 0";
+
+        auto foo = [](Series s){return s;};
+        EXPECT_PRED2(Series::equal, foo(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
+                            << "Expect implicit conversion from SeriesMask to Series is possible so that you can pass a SeriesMask to a function expecting a Series";
+
+    }
+
+    TEST(Series, from_map) {
+        EXPECT_PRED2(Series::equal, Series::from_map({}), Series());
+
+        EXPECT_PRED2(Series::equal, Series::from_map({{1, 3},
+                                                      {2, 4}}), Series({3, 4}, {1, 2}));
+
+    }
+
+    TEST(Series, equal) {
+        EXPECT_PRED2(Series::equal, Series(), Series()) << "Expect " << "empty Series' match";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                     Series(arma::vec({3, 4}), arma::vec({1, 2})));
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({NAN}), arma::vec({1})),
+                     Series(arma::vec({NAN}), arma::vec({1})))
+                            << "Expect " << "simple indices with NAN match";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
+                     Series(arma::vec({}), arma::vec({})))
+                            << "Expect " << "empty indices match";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})),
+                     Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})))
+                            << "Expect " << "longer indices with NANs match";
+    }
+
+    TEST(Series, not_equal) {
+        EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                     Series(arma::vec({1, 2}), arma::vec({1, 2})))
+                            << "Expect " << "index match does not imply Series match";
+
+        EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                     Series(arma::vec({3, 4}), arma::vec({3, 4})))
+                            << "Expect " << "values match does not imply Series match";
+
+        EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+                     Series(arma::vec({1, 2}), arma::vec({3, 4})))
+                            << "Expect " << "swapping index and values results in no match" << "";
+    }
+
+    TEST(Series, where) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), 17),
+                Series({17, 4}, {1, 2})
+        ) << "Expect " << "simple where()  to select correctly";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), NAN),
+                Series({NAN, 4}, {1, 2})
+        ) << "Expect " << ".where(..., NAN) to not set everything to NAN";
+    }
+
+    TEST(Series, DiffTest) {
+        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).diff(),
+                     Series(arma::vec({NAN, 1}), arma::vec({1, 2})))
+                            << "Expect " << "simple diff() fixture result to be correct" << "";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({4, 3}), arma::vec({1, 2})).diff(),
+                     Series(arma::vec({NAN, -1}), arma::vec({1, 2})))
+                            << "Expect " << "simple diff() fixture result to be correct" << "";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({3}), arma::vec({1})).diff(),
+                     Series(arma::vec({NAN}), arma::vec({1})))
+                            << "Expect " << "simple diff() fixture result to be correct" << "";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).diff(),
+                     Series(arma::vec({}), arma::vec({})))
+                            << "Expect " << "exmpty indices diff() fixture result to be correct" << "";
+    }
+
+    TEST(Series, abs) {
+        EXPECT_PRED2(Series::equal,
+                     Series(arma::vec({0, 3, 4, -2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})).abs(),
+                     Series(arma::vec({0, 3, 4, 2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})))
+                            << "Expect " << "negative values to be positive and rest to remain the same.";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
+                     Series(arma::vec({}), arma::vec({})))
+                            << "Expect " << "empty Series .abs() to return empty Series";
+    }
+
+    TEST(Series, PowTest) {
+        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(2),
+                     Series(arma::vec({9, 16}), arma::vec({1, 2})))
+                            << "Expect " << "simple pow() fixture result to be correct" << "";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(3),
+                     Series(arma::vec({27, 64}), arma::vec({1, 2})))
+                            << "Expect " << "simple pow() fixture result to be correct" << "";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({9}), arma::vec({1})).pow(0.5),
+                     Series(arma::vec({3}), arma::vec({1})))
+                            << "Expect " << "simple pow() fixture result to be correct" << "";
+
+        EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
+                     Series(arma::vec({}), arma::vec({})))
+                            << "Expect " << "empty indices pow() fixture result to be correct" << "";
+    }
+
+    TEST(Series, fillna) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 0, 3, 0, 5}, {1, 2, 3, 4, 5}),
+                Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna()
+        ) << "Expect " << "replace NANs with zeros";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 1, 3, 1, 5}, {1, 2, 3, 4, 5}),
+                Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna(1.)
+        ) << "Expect " << "replace NANs with ones";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).fillna()
+        ) << "Expect " << " remains the same as no NANs";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series(),
+                Series().fillna()
+        ) << "Expect " << " empty array";
+
+    }
+
+    TEST(Series, dropna) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 3, 5}, {1, 3, 5}),
+                Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).dropna()
+        ) << "Expect " << "drop NANs so indices only contains finite elements";
 
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).dropna()
-		) << "Expect " << " remains the same as no NANs";
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+                Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).dropna()
+        ) << "Expect " << " remains the same as no NANs";
 
-		EXPECT_PRED2(
-				Series::equal,
-				Series(),
-				Series().dropna()
-		) << "Expect " << " empty array";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, arma::datum::inf, 3}, {1, 2, 4}),
-				Series({1, arma::datum::inf, NAN, 3}, {1, 2, 3, 4}).dropna()
-		) << "Expect " << " drops NA and preserves inf";
-	}
-
-	TEST(Series, clipTest) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series(arma::vec({}), arma::vec({})).clip(0, 1),
-				Series(arma::vec({}), arma::vec({}))
-		) << "Expect " << "empty Series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(2, 3),
-				Series(arma::vec({2, 2, 3, 3}), arma::vec({1, 2, 3, 4}))
-		) << "Expect " << "indices clipped to 2-3";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(0, 1),
-				Series(arma::vec({1, 1, 1, 1}), arma::vec({1, 2, 3, 4}))
-		) << "Expect " << "indices clipped to 2-3";
-	}
-
-	TEST(Series, CountTest) {
-		EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
-							<< "Expect " << "simple count() fixture result to be correct" << "";
-
-		EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
-
-		EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
-							<< "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-	}
-
-	TEST(Series, SumTest) {
-		EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
-							<< "Expect " << "simple sum() fixture result to be correct" << "";
-
-		ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
-									<< "Expect " << "empty series sum() should be NAN" << "";
-
-		EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
-							<< "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-	}
-
-	TEST(Series, MeanTest) {
-		EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
-							<< "Expect " << "simple mean() fixture result to be correct" << "";
-
-		ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).mean()))
-									<< "Expect " << "empty series mean() should be NAN" << "";
-
-		EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
-							<< "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-	}
-
-	TEST(Series, StdTest) {
-		auto root_2 = std::pow(2, .5);
-		EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
-							<< "Expect " << "simple std() fixture result to be correct" << "";
-
-		EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
-							<< "Expect " << "simple std() fixture result to be correct" << "";
-
-		ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
-									<< "Expect " << "empty series std() should be NAN" << "";
-
-		ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
-									<< "Expect " << "Series with 1 element std() should be NAN";
-
-		EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
-							<< "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-	}
-
-	TEST(Series, operator__add) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series() + 1,
-				Series()
-		) << "Expect " << "empty Series stays empty";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4}, {1, 2}) + 1,
-				Series({4, 5}, {1, 2})
-		) << "Expect " << "adding 1 increases the values, not the index";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, arma::datum::nan}, {1, 2, 3}) + 1,
-				Series({4, 5, arma::datum::nan}, {1, 2, 3})
-		) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) +
-				Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-				Series({6, -1, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-		) << "Expect " << "adding positive and negative values works and nan results in nan";
-	}
-
-
-	TEST(Series, operator__subtract) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series() - 1,
-				Series()
-		) << "Expect " << "empty Series stays empty";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4}, {1, 2}) - 1,
-				Series({2, 3}, {1, 2})
-		) << "Expect " << "adding 1 increases the values, not the index";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, arma::datum::nan}, {1, 2, 3}) - 1,
-				Series({2, 3, arma::datum::nan}, {1, 2, 3})
-		) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) -
-				Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-				Series({-6, 9, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-		) << "Expect " << "subtracting positive and negative values works and nan results in nan";
-	}
-
-
-	TEST(Series, operator__multiply) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series() * 2,
-				Series()
-		) << "Expect " << "empty Series stays empty";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4}, {1, 2}) * 2,
-				Series({6, 8}, {1, 2})
-		) << "Expect " << "multiplying by 2 changes the values, not the index";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, arma::datum::nan}, {1, 2, 3}) * 2,
-				Series({6, 8, arma::datum::nan}, {1, 2, 3})
-		) << "Expect " << "multiplying by 2 changes the values, not the index, and ignores nan";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) *
-				Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-				Series({-9, -20, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-		) << "Expect " << "multiplying positive and negative values works and nan results in nan";
-	}
-
-
-	TEST(Series, operator__eq) {
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series() == Series(),
-				polars::SeriesMask()
-		) << "Expect " << "empty Series stays empty";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, 1, 2, NAN}, {1, 2, 3, 4}) ==
-				Series({0, 1, 3, NAN}, {1, 2, 3, 4}),
-				polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
-		) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series() == 1,
-				polars::SeriesMask()
-		) << "Expect " << "empty Series stays empty";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) == 2,
-				polars::SeriesMask({0, 0, 1, 1, 0}, {1, 2, 3, 4, 5})
-		) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-	}
-
-
-	TEST(Series, operator__ne) {
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series() != 1,
-				polars::SeriesMask()
-		) << "Expect " << "empty Series stays empty";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) != 2,
-				polars::SeriesMask({1, 1, 0, 0, 0}, {1, 2, 3, 4, 5})
-		) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-	}
-
-	TEST(Series, operator__gt) {
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series() > Series(),
-				polars::SeriesMask()
-		) << "Expect " << "empty Series stays empty";
-
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >
-				Series({0, -2, 2, NAN}, {1, 2, 3, 4}),
-				polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
-		) << "Expect " << "> should work as per pair, including NAN != NAN";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >= 0,
-				polars::SeriesMask({1, 0, 1, 0}, {1, 2, 3, 4})
-		) << "Expect " << ">= should work per item, including NAN != NAN";
-	}
-
-	TEST(Series, operator__lt) {
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series() < Series(),
-				polars::SeriesMask()
-		) << "Expect " << "empty Series stays empty";
-
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, -2, 2, NAN}, {1, 2, 3, 4}) <
-				Series({0, -1, 3, NAN}, {1, 2, 3, 4}),
-				polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
-		) << "Expect " << "> should work as per pair, including NAN != NAN";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
-				polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
-		) << "Expect " << "<= should work per item, including NAN != NAN";
-
-		EXPECT_PRED2(
-				polars::SeriesMask::equal,
-				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) < 0,
-				polars::SeriesMask({0, 1, 0, 0}, {1, 2, 3, 4})
-		) << "Expect " << "< should work per item, including NAN != NAN";
-	}
-
-
-	TEST(Series, apply) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1., 2., 3.}, {1, 2, 3}),
-				Series({1., 2., 3.}, {1, 2, 3}).apply(abs)
-		) << "Expect " << " should remain ideantical";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1., 2., 3.}, {1, 2, 3}),
-				Series({-1., -2., -3.}, {1, 2, 3}).apply(abs)
-		) << "Expect " << " should flip signs";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({2.7182818284590451, 7.3890560989306504, 20.085536923187668}, {1, 2, 3}),
-				Series({1., 2., 3.}, {1, 2, 3}).apply(exp)
-		) << "Expect " << " should apply exponential";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({0, 0.19, 1.9, 1.9}, {1, 2, 3, 4}).apply(exp),
-				Series({1., 1.2092495976572515, 6.6858944422792685, 6.6858944422792685}, {1, 2, 3, 4})
-		) << "Expect " << " should apply exponential";
-
-	}
-
-	TEST(Series, quantile) {
-
-		EXPECT_TRUE(std::isnan(Series().quantile())) << "Expect" << " NAN for empty array";
-
-		EXPECT_EQ(Series({1}, {1}).quantile(1), 1) << "Expect" << " one";
-
-		EXPECT_EQ(Series({1, 2, 3}, {1, 2, 3}).quantile(), 2) << "Expect" << " median as default";
-
-		EXPECT_FLOAT_EQ(Series({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).quantile(0.3), 2.7)
-							<< "Expect" << " 0.3 quantile";
-
-	}
-
-	TEST(Series, iloc) {
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series(),
-				Series().iloc(1,3)
-		) << "Expect " << "empty series";
-
-
-		EXPECT_EQ(
-				Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
-				3
-		) << "Expect " << " element 3 to be retrieved";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 2}, {1, 2}).iloc(0, 0),
-				Series({}, {})
-		)  << "Expect " << " empty series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 2}, {1, 2}).iloc(2, 2),
-				Series({}, {})
-		)  << "Expect " << " empty series";
-
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({1, 2}, {1, 2}).iloc(0, 10),
-				Series({1, 2}, {1, 2})
-		)  << "Expect " << " same series since to > series size and from is positive";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({0,1,2,3}, {0,1,2,3}),
-				Series({0,1,2,3}, {0,1,2,3}).iloc(0, 4)
-		) << "Expect " << " same series since to > series size and from is positive";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({0, 2}, {0, 2}),
-				Series({0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}).iloc(0,4,2)
-		) << "Expect " << " slice of series with step 2";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(1, 6),
-				Series({8, 9, 10, 11, 12}, {8, 9, 10, 11, 12})
-		) << "Expect " << " subseries given from and to > 0 ";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({}, {}).iloc(-4, -2),
-				Series({}, {})
-		)  << "Expect " << " empty series input sliced to give empty series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(2, -1),
-				Series({5}, {5})
-		) << "Expect " << " third element given positive from, and negative to";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(-3, -1),
-				Series({4, 5}, {4, 5})
-		) << "Expect " << " middle elements given negative from, and negative to";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({10,11}, {10,11}),
-				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 5)
-		) << "Expect " << " middle elements given negative from, and positive to";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({12}, {12}),
-				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-1, 6)
-		) << "Expect " << " last element given negative from, and positive to of the size of the series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({10, 11, 12}, {10, 11, 12}),
-				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 6)
-		) << "Expect " << " last elements given negative from, and positive to of the size of the series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, 5, 6, 7}, {3, 4, 5, 6, 7}).iloc(-3, 0),
-				Series()
-		) << " empty series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(0, -3),
-				Series({3}, {3})
-		) << " first element given negative value of size of array + 1";
-
-		auto indices = arma::uvec{1, 2};
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
-				Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
-
-	}
-
-	TEST(Series, loc) {
-
-		auto labels = arma::vec{3, 4};
-		EXPECT_PRED2(
-				Series::equal,
-				Series({2, 3, 4, 10}, {3, 4, 5, 6}).loc(labels),
-				Series({2, 3}, {3, 4})
-		) << "Expect " << " indices values retrieved by label";
-
-		auto non_valid_labels = arma::vec{30, 40};
-		EXPECT_PRED2(
-				Series::equal,
-				Series({30, 40, 53, 32}, {3, 4, 5, 6}).loc(non_valid_labels),
-				Series()
-		) << "Expect " << " empty indices since no records match labels";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(4),
-				Series({30}, {4})
-		) << "Expect " << "indices values retrieved by label";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(8),
-				Series()
-		) << "Expect " << "empty indices since no records match label";
-	}
-
-	TEST(Series, index_as_series) {
-		EXPECT_PRED2(
-				Series::equal,
-				Series().index_as_series(),
-				Series()
-		) << "Expect " << " empty series";
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series({4, 5, 6, 3}, {1, 2, 3, 4}).index_as_series(),
-				Series({1, 2, 3, 4}, {1, 2, 3, 4})
-		) << "Expect " << "index as a series";
-	}
-
-	TEST(Series, from_vect) {
-
-		std::vector<double> z = {1, 2, 3, 4};
-
-		EXPECT_PRED2(
-				Series::equal,
-				Series::from_vect(z, z),
-				Series({1, 2, 3, 4}, {1, 2, 3, 4})
-		) << "Expect " << "identical indices due to passing vectors";
-
-		std::vector<double> y = {};
-		EXPECT_PRED2(
-				Series::equal,
-				Series::from_vect(y, y),
-				Series({}, {})
-		) << "Expect " << "identical indices due to passing vectors";
-	}
-
-	TEST(Series, to_map) {
-
-		Series z = Series({10, 20, 30, 40}, {1, 2, 3, 4});
-
-		int i = 0;
-		for (auto &pair : z.to_map()) {
-			auto key = pair.first;
-			auto value = pair.second;
-
-			EXPECT_EQ(key, z.index()[i]);
-			EXPECT_EQ(value, z.values()[i]);
-			i++;
-		}
-
-		EXPECT_TRUE(Series().to_map().empty());
-	}
-
-	TEST(Series, head) {
-
-		Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.head(),
-				Series({10, 20, 30, 40, 50}, {1, 2, 3, 4, 5})
-		);
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.head(3),
-				Series({10, 20, 30}, {1, 2, 3,})
-		);
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.head(0),
-				Series()
-		);
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.head(10),
-				z
-		);
-
-	}
-
-	TEST(Series, tail) {
-
-		Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.tail(),
-				Series({20, 30, 40, 50, 60}, {2, 3, 4, 5, 6})
-		);
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.tail(3),
-				Series({40, 50, 60}, {4, 5, 6})
-		);
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.tail(0),
-				Series()
-		);
-
-		EXPECT_PRED2(
-				Series::equal,
-				z.tail(10),
-				z
-		);
-	}
-
-	TEST(Series, rolling_window_size_correction){
-
-		arma::vec input_values = {0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1};
-		arma::vec input_timestamps = {1, 2, 3, 4, 5, 6, 7, 8};
-
-		Series new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
-
-		EXPECT_PRED2(
-				Series::equal,
-				new_input_series,
-				Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
-					   {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
-		) << "Expect" << " additional 4 NANs at the beginning for window size even";
-
-		new_input_series = _window_size_correction(11, false, Series(input_values, input_timestamps));
-
-		EXPECT_PRED2(
-				Series::equal,
-				new_input_series,
-				Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
-					   {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
-		) << "Expect" << " additional 4 NANs at the beginning for window size odd";
-
-		input_timestamps = {0, 3, 6, 9, 12, 15, 18, 21};
-
-		new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
-
-		EXPECT_PRED2(
-				Series::equal,
-				new_input_series,
-				Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
-					   {-12, -9, -6, -3, 0, 3, 6, 9, 12, 15, 18, 21})
-		) << "Expect" << " additional 4 NANs at the beginning for window size odd";
-	}
-
-	TEST(Series, rolling_exp_input_correction){
-
-		EXPECT_PRED2(Series::equal, Series(), _ewm_input_correction({})) << "Expect" << " empty input series to return empty series";
-		EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, 5, 6, 7}, {-2, -1, 0, 1, 2, 3}), _ewm_input_correction({{5, 6, 7}, {1, 2, 3}}));
-		EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, NAN, 5, 6, 7, 8}, {-3, -2, -1, 0, 1, 2, 3, 4}), _ewm_input_correction({{5, 6, 7, 8}, {1, 2, 3, 4}}));
-
-	}
-
-	TEST(Series, arctan2_regular_case){
-
-		EXPECT_PRED2(
-				Series::almost_equal,
-				Series({0.07677189126977804, 0.5880026035475675, 0.04441521524691084, 0.15534206565122174, 2.214297435588181}, {1, 2, 3, 4, 5}),
-				Series::arctan2(Series({0.1, 0.2, 0.2, 0.83, 0.4}, {1, 2, 3, 4, 5}),
-								Series({1.3, 0.3, 4.5, 5.3, -0.3}, {1, 2, 3, 4, 5}))
-		) << "Expect" << " series where each element is the arctan2 of the corresponding series components in x and y.";
-
-	}
-
-	TEST(Series, concat){
-		EXPECT_PRED2(
-				Series::almost_equal,
-				Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
-				Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6}))
-		) << "Expect" << " series become concatenated one to the other.";
-
-		EXPECT_PRED2(
-				Series::almost_equal,
-				Series({1,NAN,NAN,4,5,6},{1,2,3,4,5,6}),
-				Series::concat(Series({1,NAN,NAN},{1,2,3}), Series({4,5,6},{4,5,6}))
-		) << "Expect" << " series become concatenated one to the other even with NANs.";
-
-		EXPECT_PRED2(
-				Series::almost_equal,
-				Series({1,2,3},{1,2,3}),
-				Series::concat(Series({1,2,3},{1,2,3}), Series({},{}))
-		) << "Expect" << " input series as we are concatenating an empty series.";
-
-		EXPECT_PRED2(
-				Series::almost_equal,
-				Series({1,2,3},{1,2,3}),
-				Series::concat(Series({},{}), Series({1,2,3},{1,2,3}))
-		) << "Expect" << " input series as we are concatenating an empty series.";
-
-		EXPECT_PRED2(
-				Series::almost_equal,
-				Series(),
-				Series::concat(Series(), Series())
-		) << "Expect" << " an empty series.";
-	}
-	
-
-	TEST(Series, interval_edges) {
-		// Odd WindowSize Even Input
-		EXPECT_TRUE(_get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
-		EXPECT_TRUE(_get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
-
-		EXPECT_TRUE(_get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
-		EXPECT_TRUE(_get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
-
-		EXPECT_TRUE(_get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
-		EXPECT_TRUE(_get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
-
-		// Even WindowSize Odd Input
-		EXPECT_TRUE(_get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
-		EXPECT_TRUE(_get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
-
-		EXPECT_TRUE(_get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
-		EXPECT_TRUE(_get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
-
-		EXPECT_TRUE(_get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
-		EXPECT_TRUE(_get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
-
-		// Odd WindowSize Odd Input
-		EXPECT_TRUE(_get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
-		EXPECT_TRUE(_get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
-
-		EXPECT_TRUE(_get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
-		EXPECT_TRUE(_get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
-
-		EXPECT_TRUE(_get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
-		EXPECT_TRUE(_get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
-
-		// Even WindowSize Even Input
-		EXPECT_TRUE(_get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
-		EXPECT_TRUE(_get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
-
-		EXPECT_TRUE(_get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
-		EXPECT_TRUE(_get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
-
-		EXPECT_TRUE(_get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
-		EXPECT_TRUE(_get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
-
-		// Window = Input
-		EXPECT_TRUE(_get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
-		EXPECT_TRUE(_get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
-
-		EXPECT_TRUE(_get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
-		EXPECT_TRUE(_get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
-
-		EXPECT_TRUE(_get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
-		EXPECT_TRUE(_get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
-	}
+        EXPECT_PRED2(
+                Series::equal,
+                Series(),
+                Series().dropna()
+        ) << "Expect " << " empty array";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, arma::datum::inf, 3}, {1, 2, 4}),
+                Series({1, arma::datum::inf, NAN, 3}, {1, 2, 3, 4}).dropna()
+        ) << "Expect " << " drops NA and preserves inf";
+    }
+
+    TEST(Series, clipTest) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series(arma::vec({}), arma::vec({})).clip(0, 1),
+                Series(arma::vec({}), arma::vec({}))
+        ) << "Expect " << "empty Series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(2, 3),
+                Series(arma::vec({2, 2, 3, 3}), arma::vec({1, 2, 3, 4}))
+        ) << "Expect " << "indices clipped to 2-3";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(0, 1),
+                Series(arma::vec({1, 1, 1, 1}), arma::vec({1, 2, 3, 4}))
+        ) << "Expect " << "indices clipped to 2-3";
+    }
+
+    TEST(Series, CountTest) {
+        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
+                            << "Expect " << "simple count() fixture result to be correct" << "";
+
+        EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
+
+        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
+                            << "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
+    TEST(Series, SumTest) {
+        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
+                            << "Expect " << "simple sum() fixture result to be correct" << "";
+
+        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
+                                    << "Expect " << "empty series sum() should be NAN" << "";
+
+        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
+                            << "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
+    TEST(Series, MeanTest) {
+        EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
+                            << "Expect " << "simple mean() fixture result to be correct" << "";
+
+        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).mean()))
+                                    << "Expect " << "empty series mean() should be NAN" << "";
+
+        EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
+                            << "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
+    TEST(Series, StdTest) {
+        auto root_2 = std::pow(2, .5);
+        EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
+                            << "Expect " << "simple std() fixture result to be correct" << "";
+
+        EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
+                            << "Expect " << "simple std() fixture result to be correct" << "";
+
+        ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
+                                    << "Expect " << "empty series std() should be NAN" << "";
+
+        ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
+                                    << "Expect " << "Series with 1 element std() should be NAN";
+
+        EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
+                            << "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+    }
+
+    TEST(Series, operator__add) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series() + 1,
+                Series()
+        ) << "Expect " << "empty Series stays empty";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4}, {1, 2}) + 1,
+                Series({4, 5}, {1, 2})
+        ) << "Expect " << "adding 1 increases the values, not the index";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, arma::datum::nan}, {1, 2, 3}) + 1,
+                Series({4, 5, arma::datum::nan}, {1, 2, 3})
+        ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) +
+                Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+                Series({6, -1, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+        ) << "Expect " << "adding positive and negative values works and nan results in nan";
+    }
+
+
+    TEST(Series, operator__subtract) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series() - 1,
+                Series()
+        ) << "Expect " << "empty Series stays empty";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4}, {1, 2}) - 1,
+                Series({2, 3}, {1, 2})
+        ) << "Expect " << "adding 1 increases the values, not the index";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, arma::datum::nan}, {1, 2, 3}) - 1,
+                Series({2, 3, arma::datum::nan}, {1, 2, 3})
+        ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) -
+                Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+                Series({-6, 9, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+        ) << "Expect " << "subtracting positive and negative values works and nan results in nan";
+    }
+
+
+    TEST(Series, operator__multiply) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series() * 2,
+                Series()
+        ) << "Expect " << "empty Series stays empty";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4}, {1, 2}) * 2,
+                Series({6, 8}, {1, 2})
+        ) << "Expect " << "multiplying by 2 changes the values, not the index";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, arma::datum::nan}, {1, 2, 3}) * 2,
+                Series({6, 8, arma::datum::nan}, {1, 2, 3})
+        ) << "Expect " << "multiplying by 2 changes the values, not the index, and ignores nan";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) *
+                Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+                Series({-9, -20, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+        ) << "Expect " << "multiplying positive and negative values works and nan results in nan";
+    }
+
+
+    TEST(Series, operator__eq) {
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series() == Series(),
+                polars::SeriesMask()
+        ) << "Expect " << "empty Series stays empty";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, 1, 2, NAN}, {1, 2, 3, 4}) ==
+                Series({0, 1, 3, NAN}, {1, 2, 3, 4}),
+                polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
+        ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series() == 1,
+                polars::SeriesMask()
+        ) << "Expect " << "empty Series stays empty";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) == 2,
+                polars::SeriesMask({0, 0, 1, 1, 0}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+    }
+
+
+    TEST(Series, operator__ne) {
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series() != 1,
+                polars::SeriesMask()
+        ) << "Expect " << "empty Series stays empty";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) != 2,
+                polars::SeriesMask({1, 1, 0, 0, 0}, {1, 2, 3, 4, 5})
+        ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+    }
+
+    TEST(Series, operator__gt) {
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series() > Series(),
+                polars::SeriesMask()
+        ) << "Expect " << "empty Series stays empty";
+
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >
+                Series({0, -2, 2, NAN}, {1, 2, 3, 4}),
+                polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
+        ) << "Expect " << "> should work as per pair, including NAN != NAN";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >= 0,
+                polars::SeriesMask({1, 0, 1, 0}, {1, 2, 3, 4})
+        ) << "Expect " << ">= should work per item, including NAN != NAN";
+    }
+
+    TEST(Series, operator__lt) {
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series() < Series(),
+                polars::SeriesMask()
+        ) << "Expect " << "empty Series stays empty";
+
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, -2, 2, NAN}, {1, 2, 3, 4}) <
+                Series({0, -1, 3, NAN}, {1, 2, 3, 4}),
+                polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
+        ) << "Expect " << "> should work as per pair, including NAN != NAN";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
+                polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
+        ) << "Expect " << "<= should work per item, including NAN != NAN";
+
+        EXPECT_PRED2(
+                polars::SeriesMask::equal,
+                Series({0, -1, 3, NAN}, {1, 2, 3, 4}) < 0,
+                polars::SeriesMask({0, 1, 0, 0}, {1, 2, 3, 4})
+        ) << "Expect " << "< should work per item, including NAN != NAN";
+    }
+
+
+    TEST(Series, apply) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1., 2., 3.}, {1, 2, 3}),
+                Series({1., 2., 3.}, {1, 2, 3}).apply(abs)
+        ) << "Expect " << " should remain ideantical";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1., 2., 3.}, {1, 2, 3}),
+                Series({-1., -2., -3.}, {1, 2, 3}).apply(abs)
+        ) << "Expect " << " should flip signs";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({2.7182818284590451, 7.3890560989306504, 20.085536923187668}, {1, 2, 3}),
+                Series({1., 2., 3.}, {1, 2, 3}).apply(exp)
+        ) << "Expect " << " should apply exponential";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({0, 0.19, 1.9, 1.9}, {1, 2, 3, 4}).apply(exp),
+                Series({1., 1.2092495976572515, 6.6858944422792685, 6.6858944422792685}, {1, 2, 3, 4})
+        ) << "Expect " << " should apply exponential";
+
+    }
+
+    TEST(Series, quantile) {
+
+        EXPECT_TRUE(std::isnan(Series().quantile())) << "Expect" << " NAN for empty array";
+
+        EXPECT_EQ(Series({1}, {1}).quantile(1), 1) << "Expect" << " one";
+
+        EXPECT_EQ(Series({1, 2, 3}, {1, 2, 3}).quantile(), 2) << "Expect" << " median as default";
+
+        EXPECT_FLOAT_EQ(Series({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).quantile(0.3), 2.7)
+                            << "Expect" << " 0.3 quantile";
+
+    }
+
+    TEST(Series, iloc) {
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series(),
+                Series().iloc(1,3)
+        ) << "Expect " << "empty series";
+
+
+        EXPECT_EQ(
+                Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
+                3
+        ) << "Expect " << " element 3 to be retrieved";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2}, {1, 2}).iloc(0, 0),
+                Series({}, {})
+        )  << "Expect " << " empty series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2}, {1, 2}).iloc(2, 2),
+                Series({}, {})
+        )  << "Expect " << " empty series";
+
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({1, 2}, {1, 2}).iloc(0, 10),
+                Series({1, 2}, {1, 2})
+        )  << "Expect " << " same series since to > series size and from is positive";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({0,1,2,3}, {0,1,2,3}),
+                Series({0,1,2,3}, {0,1,2,3}).iloc(0, 4)
+        ) << "Expect " << " same series since to > series size and from is positive";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({0, 2}, {0, 2}),
+                Series({0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}).iloc(0,4,2)
+        ) << "Expect " << " slice of series with step 2";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(1, 6),
+                Series({8, 9, 10, 11, 12}, {8, 9, 10, 11, 12})
+        ) << "Expect " << " subseries given from and to > 0 ";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({}, {}).iloc(-4, -2),
+                Series({}, {})
+        )  << "Expect " << " empty series input sliced to give empty series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(2, -1),
+                Series({5}, {5})
+        ) << "Expect " << " third element given positive from, and negative to";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(-3, -1),
+                Series({4, 5}, {4, 5})
+        ) << "Expect " << " middle elements given negative from, and negative to";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({10,11}, {10,11}),
+                Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 5)
+        ) << "Expect " << " middle elements given negative from, and positive to";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({12}, {12}),
+                Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-1, 6)
+        ) << "Expect " << " last element given negative from, and positive to of the size of the series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({10, 11, 12}, {10, 11, 12}),
+                Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 6)
+        ) << "Expect " << " last elements given negative from, and positive to of the size of the series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, 5, 6, 7}, {3, 4, 5, 6, 7}).iloc(-3, 0),
+                Series()
+        ) << " empty series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(0, -3),
+                Series({3}, {3})
+        ) << " first element given negative value of size of array + 1";
+
+        auto indices = arma::uvec{1, 2};
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
+                Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
+
+    }
+
+    TEST(Series, loc) {
+
+        auto labels = arma::vec{3, 4};
+        EXPECT_PRED2(
+                Series::equal,
+                Series({2, 3, 4, 10}, {3, 4, 5, 6}).loc(labels),
+                Series({2, 3}, {3, 4})
+        ) << "Expect " << " indices values retrieved by label";
+
+        auto non_valid_labels = arma::vec{30, 40};
+        EXPECT_PRED2(
+                Series::equal,
+                Series({30, 40, 53, 32}, {3, 4, 5, 6}).loc(non_valid_labels),
+                Series()
+        ) << "Expect " << " empty indices since no records match labels";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(4),
+                Series({30}, {4})
+        ) << "Expect " << "indices values retrieved by label";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(8),
+                Series()
+        ) << "Expect " << "empty indices since no records match label";
+    }
+
+    TEST(Series, index_as_series) {
+        EXPECT_PRED2(
+                Series::equal,
+                Series().index_as_series(),
+                Series()
+        ) << "Expect " << " empty series";
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series({4, 5, 6, 3}, {1, 2, 3, 4}).index_as_series(),
+                Series({1, 2, 3, 4}, {1, 2, 3, 4})
+        ) << "Expect " << "index as a series";
+    }
+
+    TEST(Series, from_vect) {
+
+        std::vector<double> z = {1, 2, 3, 4};
+
+        EXPECT_PRED2(
+                Series::equal,
+                Series::from_vect(z, z),
+                Series({1, 2, 3, 4}, {1, 2, 3, 4})
+        ) << "Expect " << "identical indices due to passing vectors";
+
+        std::vector<double> y = {};
+        EXPECT_PRED2(
+                Series::equal,
+                Series::from_vect(y, y),
+                Series({}, {})
+        ) << "Expect " << "identical indices due to passing vectors";
+    }
+
+    TEST(Series, to_map) {
+
+        Series z = Series({10, 20, 30, 40}, {1, 2, 3, 4});
+
+        int i = 0;
+        for (auto &pair : z.to_map()) {
+            auto key = pair.first;
+            auto value = pair.second;
+
+            EXPECT_EQ(key, z.index()[i]);
+            EXPECT_EQ(value, z.values()[i]);
+            i++;
+        }
+
+        EXPECT_TRUE(Series().to_map().empty());
+    }
+
+    TEST(Series, head) {
+
+        Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.head(),
+                Series({10, 20, 30, 40, 50}, {1, 2, 3, 4, 5})
+        );
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.head(3),
+                Series({10, 20, 30}, {1, 2, 3,})
+        );
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.head(0),
+                Series()
+        );
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.head(10),
+                z
+        );
+
+    }
+
+    TEST(Series, tail) {
+
+        Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.tail(),
+                Series({20, 30, 40, 50, 60}, {2, 3, 4, 5, 6})
+        );
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.tail(3),
+                Series({40, 50, 60}, {4, 5, 6})
+        );
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.tail(0),
+                Series()
+        );
+
+        EXPECT_PRED2(
+                Series::equal,
+                z.tail(10),
+                z
+        );
+    }
+
+    TEST(Series, rolling_window_size_correction){
+
+        arma::vec input_values = {0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1};
+        arma::vec input_timestamps = {1, 2, 3, 4, 5, 6, 7, 8};
+
+        Series new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
+
+        EXPECT_PRED2(
+                Series::equal,
+                new_input_series,
+                Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+                       {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
+        ) << "Expect" << " additional 4 NANs at the beginning for window size even";
+
+        new_input_series = _window_size_correction(11, false, Series(input_values, input_timestamps));
+
+        EXPECT_PRED2(
+                Series::equal,
+                new_input_series,
+                Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+                       {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
+        ) << "Expect" << " additional 4 NANs at the beginning for window size odd";
+
+        input_timestamps = {0, 3, 6, 9, 12, 15, 18, 21};
+
+        new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
+
+        EXPECT_PRED2(
+                Series::equal,
+                new_input_series,
+                Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+                       {-12, -9, -6, -3, 0, 3, 6, 9, 12, 15, 18, 21})
+        ) << "Expect" << " additional 4 NANs at the beginning for window size odd";
+    }
+
+    TEST(Series, rolling_exp_input_correction){
+
+        EXPECT_PRED2(Series::equal, Series(), _ewm_input_correction({})) << "Expect" << " empty input series to return empty series";
+        EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, 5, 6, 7}, {-2, -1, 0, 1, 2, 3}), _ewm_input_correction({{5, 6, 7}, {1, 2, 3}}));
+        EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, NAN, 5, 6, 7, 8}, {-3, -2, -1, 0, 1, 2, 3, 4}), _ewm_input_correction({{5, 6, 7, 8}, {1, 2, 3, 4}}));
+
+    }
+
+    TEST(Series, arctan2_regular_case){
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({0.07677189126977804, 0.5880026035475675, 0.04441521524691084, 0.15534206565122174, 2.214297435588181}, {1, 2, 3, 4, 5}),
+                Series::arctan2(Series({0.1, 0.2, 0.2, 0.83, 0.4}, {1, 2, 3, 4, 5}),
+                                Series({1.3, 0.3, 4.5, 5.3, -0.3}, {1, 2, 3, 4, 5}))
+        ) << "Expect" << " series where each element is the arctan2 of the corresponding series components in x and y.";
+
+    }
+
+    TEST(Series, concat){
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
+                Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6}))
+        ) << "Expect" << " series become concatenated one to the other.";
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({1,NAN,NAN,4,5,6},{1,2,3,4,5,6}),
+                Series::concat(Series({1,NAN,NAN},{1,2,3}), Series({4,5,6},{4,5,6}))
+        ) << "Expect" << " series become concatenated one to the other even with NANs.";
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({1,2,3},{1,2,3}),
+                Series::concat(Series({1,2,3},{1,2,3}), Series({},{}))
+        ) << "Expect" << " input series as we are concatenating an empty series.";
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series({1,2,3},{1,2,3}),
+                Series::concat(Series({},{}), Series({1,2,3},{1,2,3}))
+        ) << "Expect" << " input series as we are concatenating an empty series.";
+
+        EXPECT_PRED2(
+                Series::almost_equal,
+                Series(),
+                Series::concat(Series(), Series())
+        ) << "Expect" << " an empty series.";
+    }
+
+
+    TEST(Series, interval_edges) {
+        // Odd WindowSize Even Input
+        EXPECT_TRUE(_get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
+        EXPECT_TRUE(_get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+        EXPECT_TRUE(_get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
+        EXPECT_TRUE(_get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+        EXPECT_TRUE(_get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
+        EXPECT_TRUE(_get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
+
+        // Even WindowSize Odd Input
+        EXPECT_TRUE(_get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
+        EXPECT_TRUE(_get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+        EXPECT_TRUE(_get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
+        EXPECT_TRUE(_get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+        EXPECT_TRUE(_get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
+        EXPECT_TRUE(_get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
+
+        // Odd WindowSize Odd Input
+        EXPECT_TRUE(_get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
+        EXPECT_TRUE(_get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+        EXPECT_TRUE(_get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
+        EXPECT_TRUE(_get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+        EXPECT_TRUE(_get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
+        EXPECT_TRUE(_get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
+
+        // Even WindowSize Even Input
+        EXPECT_TRUE(_get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
+        EXPECT_TRUE(_get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+        EXPECT_TRUE(_get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
+        EXPECT_TRUE(_get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+        EXPECT_TRUE(_get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
+        EXPECT_TRUE(_get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
+
+        // Window = Input
+        EXPECT_TRUE(_get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
+        EXPECT_TRUE(_get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+        EXPECT_TRUE(_get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
+        EXPECT_TRUE(_get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+        EXPECT_TRUE(_get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
+        EXPECT_TRUE(_get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
+    }
 
 
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -5,7 +5,6 @@
 #include "polars/Series.h"
 
 #include "polars/SeriesMask.h"
-#include "polars/numc.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -804,15 +804,7 @@ namespace SeriesTests {
 				Series::concat(Series(), Series())
 		) << "Expect" << " an empty series.";
 	}
-
-/* THIS IS HOW WE WOULD LIKE IT TO BEHAVE FOR center = false.
-TEST(Series, interval_edges_new) {
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 0) == std::make_tuple(0, 0, 2, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 1) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 2) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(_get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
-}*/
+	
 
 	TEST(Series, interval_edges) {
 		// Odd WindowSize Even Input

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -11,851 +11,862 @@
 
 
 namespace SeriesTests {
-using namespace polars;
-
-TEST(Series, constructors) {
-    EXPECT_PRED2(Series::equal, Series(SeriesMask()), Series())
-    << "Expect constructing with empty SeriesMask is the same as empty constructor";
-    EXPECT_PRED2(Series::equal, Series(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
-    << "Expect true becomes 1 and false becomes 0";
-
-    auto foo = [](Series s){return s;};
-    EXPECT_PRED2(Series::equal, foo(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
-    << "Expect implicit conversion from SeriesMask to Series is possible so that you can pass a SeriesMask to a function expecting a Series";
-
-}
-
-TEST(Series, from_map) {
-    EXPECT_PRED2(Series::equal, Series::from_map({}), Series());
-
-    EXPECT_PRED2(Series::equal, Series::from_map({{1, 3},
-                                                  {2, 4}}), Series({3, 4}, {1, 2}));
-
-}
-
-TEST(Series, equal) {
-    EXPECT_PRED2(Series::equal, Series(), Series()) << "Expect " << "empty Series' match";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                 Series(arma::vec({3, 4}), arma::vec({1, 2})));
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({NAN}), arma::vec({1})),
-                 Series(arma::vec({NAN}), arma::vec({1})))
-                        << "Expect " << "simple indices with NAN match";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
-                 Series(arma::vec({}), arma::vec({})))
-                        << "Expect " << "empty indices match";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})),
-                 Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})))
-                        << "Expect " << "longer indices with NANs match";
-}
-
-TEST(Series, not_equal) {
-    EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                 Series(arma::vec({1, 2}), arma::vec({1, 2})))
-                        << "Expect " << "index match does not imply Series match";
-
-    EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                 Series(arma::vec({3, 4}), arma::vec({3, 4})))
-                        << "Expect " << "values match does not imply Series match";
-
-    EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
-                 Series(arma::vec({1, 2}), arma::vec({3, 4})))
-                        << "Expect " << "swapping index and values results in no match" << "";
-}
-
-TEST(Series, where) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), 17),
-            Series({17, 4}, {1, 2})
-    ) << "Expect " << "simple where()  to select correctly";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), NAN),
-            Series({NAN, 4}, {1, 2})
-    ) << "Expect " << ".where(..., NAN) to not set everything to NAN";
-}
-
-TEST(Series, DiffTest) {
-    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).diff(),
-                 Series(arma::vec({NAN, 1}), arma::vec({1, 2})))
-                        << "Expect " << "simple diff() fixture result to be correct" << "";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({4, 3}), arma::vec({1, 2})).diff(),
-                 Series(arma::vec({NAN, -1}), arma::vec({1, 2})))
-                        << "Expect " << "simple diff() fixture result to be correct" << "";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({3}), arma::vec({1})).diff(),
-                 Series(arma::vec({NAN}), arma::vec({1})))
-                        << "Expect " << "simple diff() fixture result to be correct" << "";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).diff(),
-                 Series(arma::vec({}), arma::vec({})))
-                        << "Expect " << "exmpty indices diff() fixture result to be correct" << "";
-}
-
-TEST(Series, abs) {
-    EXPECT_PRED2(Series::equal,
-                 Series(arma::vec({0, 3, 4, -2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})).abs(),
-                 Series(arma::vec({0, 3, 4, 2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})))
-                        << "Expect " << "negative values to be positive and rest to remain the same.";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
-                 Series(arma::vec({}), arma::vec({})))
-                        << "Expect " << "empty Series .abs() to return empty Series";
-}
-
-TEST(Series, PowTest) {
-    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(2),
-                 Series(arma::vec({9, 16}), arma::vec({1, 2})))
-                        << "Expect " << "simple pow() fixture result to be correct" << "";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(3),
-                 Series(arma::vec({27, 64}), arma::vec({1, 2})))
-                        << "Expect " << "simple pow() fixture result to be correct" << "";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({9}), arma::vec({1})).pow(0.5),
-                 Series(arma::vec({3}), arma::vec({1})))
-                        << "Expect " << "simple pow() fixture result to be correct" << "";
-
-    EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
-                 Series(arma::vec({}), arma::vec({})))
-                        << "Expect " << "empty indices pow() fixture result to be correct" << "";
-}
-
-TEST(Series, fillna) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1, 0, 3, 0, 5}, {1, 2, 3, 4, 5}),
-            Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna()
-    ) << "Expect " << "replace NANs with zeros";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1, 1, 3, 1, 5}, {1, 2, 3, 4, 5}),
-            Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna(1.)
-    ) << "Expect " << "replace NANs with ones";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).fillna()
-    ) << "Expect " << " remains the same as no NANs";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series(),
-            Series().fillna()
-    ) << "Expect " << " empty array";
-
-}
-
-TEST(Series, dropna) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1, 3, 5}, {1, 3, 5}),
-            Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).dropna()
-    ) << "Expect " << "drop NANs so indices only contains finite elements";
+	using namespace polars;
+
+	TEST(Series, constructors) {
+		EXPECT_PRED2(Series::equal, Series(SeriesMask()), Series())
+							<< "Expect constructing with empty SeriesMask is the same as empty constructor";
+		EXPECT_PRED2(Series::equal, Series(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
+							<< "Expect true becomes 1 and false becomes 0";
+
+		auto foo = [](Series s){return s;};
+		EXPECT_PRED2(Series::equal, foo(SeriesMask({true, false}, {1, 2})), Series({1, 0}, {1, 2}))
+							<< "Expect implicit conversion from SeriesMask to Series is possible so that you can pass a SeriesMask to a function expecting a Series";
+
+	}
+
+	TEST(Series, from_map) {
+		EXPECT_PRED2(Series::equal, Series::from_map({}), Series());
+
+		EXPECT_PRED2(Series::equal, Series::from_map({{1, 3},
+													  {2, 4}}), Series({3, 4}, {1, 2}));
+
+	}
+
+	TEST(Series, equal) {
+		EXPECT_PRED2(Series::equal, Series(), Series()) << "Expect " << "empty Series' match";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+					 Series(arma::vec({3, 4}), arma::vec({1, 2})));
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({NAN}), arma::vec({1})),
+					 Series(arma::vec({NAN}), arma::vec({1})))
+							<< "Expect " << "simple indices with NAN match";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
+					 Series(arma::vec({}), arma::vec({})))
+							<< "Expect " << "empty indices match";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})),
+					 Series(arma::vec({4, NAN, 5, NAN, NAN, 6}), arma::vec({1, 2, 3, 4, 5, 6})))
+							<< "Expect " << "longer indices with NANs match";
+	}
+
+	TEST(Series, not_equal) {
+		EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+					 Series(arma::vec({1, 2}), arma::vec({1, 2})))
+							<< "Expect " << "index match does not imply Series match";
+
+		EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+					 Series(arma::vec({3, 4}), arma::vec({3, 4})))
+							<< "Expect " << "values match does not imply Series match";
+
+		EXPECT_PRED2(Series::not_equal, Series(arma::vec({3, 4}), arma::vec({1, 2})),
+					 Series(arma::vec({1, 2}), arma::vec({3, 4})))
+							<< "Expect " << "swapping index and values results in no match" << "";
+	}
+
+	TEST(Series, where) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), 17),
+				Series({17, 4}, {1, 2})
+		) << "Expect " << "simple where()  to select correctly";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4}, {1, 2}).where(polars::SeriesMask({0, 1}, {1, 2}), NAN),
+				Series({NAN, 4}, {1, 2})
+		) << "Expect " << ".where(..., NAN) to not set everything to NAN";
+	}
+
+	TEST(Series, DiffTest) {
+		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).diff(),
+					 Series(arma::vec({NAN, 1}), arma::vec({1, 2})))
+							<< "Expect " << "simple diff() fixture result to be correct" << "";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({4, 3}), arma::vec({1, 2})).diff(),
+					 Series(arma::vec({NAN, -1}), arma::vec({1, 2})))
+							<< "Expect " << "simple diff() fixture result to be correct" << "";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({3}), arma::vec({1})).diff(),
+					 Series(arma::vec({NAN}), arma::vec({1})))
+							<< "Expect " << "simple diff() fixture result to be correct" << "";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).diff(),
+					 Series(arma::vec({}), arma::vec({})))
+							<< "Expect " << "exmpty indices diff() fixture result to be correct" << "";
+	}
+
+	TEST(Series, abs) {
+		EXPECT_PRED2(Series::equal,
+					 Series(arma::vec({0, 3, 4, -2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})).abs(),
+					 Series(arma::vec({0, 3, 4, 2, 1.5, NAN}), arma::vec({1, 2, 3, 4, 5, 6})))
+							<< "Expect " << "negative values to be positive and rest to remain the same.";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
+					 Series(arma::vec({}), arma::vec({})))
+							<< "Expect " << "empty Series .abs() to return empty Series";
+	}
+
+	TEST(Series, PowTest) {
+		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(2),
+					 Series(arma::vec({9, 16}), arma::vec({1, 2})))
+							<< "Expect " << "simple pow() fixture result to be correct" << "";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({3, 4}), arma::vec({1, 2})).pow(3),
+					 Series(arma::vec({27, 64}), arma::vec({1, 2})))
+							<< "Expect " << "simple pow() fixture result to be correct" << "";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({9}), arma::vec({1})).pow(0.5),
+					 Series(arma::vec({3}), arma::vec({1})))
+							<< "Expect " << "simple pow() fixture result to be correct" << "";
+
+		EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})).pow(2),
+					 Series(arma::vec({}), arma::vec({})))
+							<< "Expect " << "empty indices pow() fixture result to be correct" << "";
+	}
+
+	TEST(Series, fillna) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 0, 3, 0, 5}, {1, 2, 3, 4, 5}),
+				Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna()
+		) << "Expect " << "replace NANs with zeros";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 1, 3, 1, 5}, {1, 2, 3, 4, 5}),
+				Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).fillna(1.)
+		) << "Expect " << "replace NANs with ones";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).fillna()
+		) << "Expect " << " remains the same as no NANs";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series(),
+				Series().fillna()
+		) << "Expect " << " empty array";
+
+	}
+
+	TEST(Series, dropna) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 3, 5}, {1, 3, 5}),
+				Series({1, NAN, 3, NAN, 5}, {1, 2, 3, 4, 5}).dropna()
+		) << "Expect " << "drop NANs so indices only contains finite elements";
 
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
-            Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).dropna()
-    ) << "Expect " << " remains the same as no NANs";
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}),
+				Series({1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}).dropna()
+		) << "Expect " << " remains the same as no NANs";
 
-    EXPECT_PRED2(
-            Series::equal,
-            Series(),
-            Series().dropna()
-    ) << "Expect " << " empty array";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1, arma::datum::inf, 3}, {1, 2, 4}),
-            Series({1, arma::datum::inf, NAN, 3}, {1, 2, 3, 4}).dropna()
-    ) << "Expect " << " drops NA and preserves inf";
-}
-
-TEST(Series, clipTest) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series(arma::vec({}), arma::vec({})).clip(0, 1),
-            Series(arma::vec({}), arma::vec({}))
-    ) << "Expect " << "empty Series";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(2, 3),
-            Series(arma::vec({2, 2, 3, 3}), arma::vec({1, 2, 3, 4}))
-    ) << "Expect " << "indices clipped to 2-3";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(0, 1),
-            Series(arma::vec({1, 1, 1, 1}), arma::vec({1, 2, 3, 4}))
-    ) << "Expect " << "indices clipped to 2-3";
-}
-
-TEST(Series, CountTest) {
-    EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
-                        << "Expect " << "simple count() fixture result to be correct" << "";
-
-    EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
-
-    EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
-                        << "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-}
-
-TEST(Series, SumTest) {
-    EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
-                        << "Expect " << "simple sum() fixture result to be correct" << "";
-
-    ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
-                                << "Expect " << "empty series sum() should be NAN" << "";
-
-    EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
-                        << "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-}
-
-TEST(Series, MeanTest) {
-    EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
-                        << "Expect " << "simple mean() fixture result to be correct" << "";
-
-    ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).mean()))
-                                << "Expect " << "empty series mean() should be NAN" << "";
-
-    EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
-                        << "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-}
-
-TEST(Series, StdTest) {
-    auto root_2 = std::pow(2, .5);
-    EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
-                        << "Expect " << "simple std() fixture result to be correct" << "";
-
-    EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
-                        << "Expect " << "simple std() fixture result to be correct" << "";
-
-    ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
-                                << "Expect " << "empty series std() should be NAN" << "";
-
-    ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
-                                << "Expect " << "Series with 1 element std() should be NAN";
-
-    EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
-                        << "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
-
-
-}
-
-TEST(Series, operator__add) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series() + 1,
-            Series()
-    ) << "Expect " << "empty Series stays empty";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4}, {1, 2}) + 1,
-            Series({4, 5}, {1, 2})
-    ) << "Expect " << "adding 1 increases the values, not the index";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4, arma::datum::nan}, {1, 2, 3}) + 1,
-            Series({4, 5, arma::datum::nan}, {1, 2, 3})
-    ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) +
-            Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-            Series({6, -1, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-    ) << "Expect " << "adding positive and negative values works and nan results in nan";
-}
-
-
-TEST(Series, operator__subtract) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series() - 1,
-            Series()
-    ) << "Expect " << "empty Series stays empty";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4}, {1, 2}) - 1,
-            Series({2, 3}, {1, 2})
-    ) << "Expect " << "adding 1 increases the values, not the index";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4, arma::datum::nan}, {1, 2, 3}) - 1,
-            Series({2, 3, arma::datum::nan}, {1, 2, 3})
-    ) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) -
-            Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-            Series({-6, 9, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-    ) << "Expect " << "subtracting positive and negative values works and nan results in nan";
-}
-
-
-TEST(Series, operator__multiply) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series() * 2,
-            Series()
-    ) << "Expect " << "empty Series stays empty";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4}, {1, 2}) * 2,
-            Series({6, 8}, {1, 2})
-    ) << "Expect " << "multiplying by 2 changes the values, not the index";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({3, 4, arma::datum::nan}, {1, 2, 3}) * 2,
-            Series({6, 8, arma::datum::nan}, {1, 2, 3})
-    ) << "Expect " << "multiplying by 2 changes the values, not the index, and ignores nan";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) *
-            Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
-            Series({-9, -20, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
-    ) << "Expect " << "multiplying positive and negative values works and nan results in nan";
-}
-
-
-TEST(Series, operator__eq) {
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series() == Series(),
-            polars::SeriesMask()
-    ) << "Expect " << "empty Series stays empty";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, 1, 2, NAN}, {1, 2, 3, 4}) ==
-            Series({0, 1, 3, NAN}, {1, 2, 3, 4}),
-            polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
-    ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series() == 1,
-            polars::SeriesMask()
-    ) << "Expect " << "empty Series stays empty";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) == 2,
-            polars::SeriesMask({0, 0, 1, 1, 0}, {1, 2, 3, 4, 5})
-    ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-}
-
-
-TEST(Series, operator__ne) {
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series() != 1,
-            polars::SeriesMask()
-    ) << "Expect " << "empty Series stays empty";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) != 2,
-            polars::SeriesMask({1, 1, 0, 0, 0}, {1, 2, 3, 4, 5})
-    ) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
-}
-
-TEST(Series, operator__gt) {
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series() > Series(),
-            polars::SeriesMask()
-    ) << "Expect " << "empty Series stays empty";
-
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >
-            Series({0, -2, 2, NAN}, {1, 2, 3, 4}),
-            polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
-    ) << "Expect " << "> should work as per pair, including NAN != NAN";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >= 0,
-            polars::SeriesMask({1, 0, 1, 0}, {1, 2, 3, 4})
-    ) << "Expect " << ">= should work per item, including NAN != NAN";
-}
-
-TEST(Series, operator__lt) {
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series() < Series(),
-            polars::SeriesMask()
-    ) << "Expect " << "empty Series stays empty";
-
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, -2, 2, NAN}, {1, 2, 3, 4}) <
-            Series({0, -1, 3, NAN}, {1, 2, 3, 4}),
-            polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
-    ) << "Expect " << "> should work as per pair, including NAN != NAN";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
-            polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
-    ) << "Expect " << "<= should work per item, including NAN != NAN";
-
-    EXPECT_PRED2(
-            polars::SeriesMask::equal,
-            Series({0, -1, 3, NAN}, {1, 2, 3, 4}) < 0,
-            polars::SeriesMask({0, 1, 0, 0}, {1, 2, 3, 4})
-    ) << "Expect " << "< should work per item, including NAN != NAN";
-}
-
-
-TEST(Series, apply) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1., 2., 3.}, {1, 2, 3}),
-            Series({1., 2., 3.}, {1, 2, 3}).apply(abs)
-    ) << "Expect " << " should remain ideantical";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({1., 2., 3.}, {1, 2, 3}),
-            Series({-1., -2., -3.}, {1, 2, 3}).apply(abs)
-    ) << "Expect " << " should flip signs";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({2.7182818284590451, 7.3890560989306504, 20.085536923187668}, {1, 2, 3}),
-            Series({1., 2., 3.}, {1, 2, 3}).apply(exp)
-    ) << "Expect " << " should apply exponential";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({0, 0.19, 1.9, 1.9}, {1, 2, 3, 4}).apply(exp),
-            Series({1., 1.2092495976572515, 6.6858944422792685, 6.6858944422792685}, {1, 2, 3, 4})
-    ) << "Expect " << " should apply exponential";
-
-}
-
-TEST(Series, quantile) {
-
-    EXPECT_TRUE(std::isnan(Series().quantile())) << "Expect" << " NAN for empty array";
-
-    EXPECT_EQ(Series({1}, {1}).quantile(1), 1) << "Expect" << " one";
-
-    EXPECT_EQ(Series({1, 2, 3}, {1, 2, 3}).quantile(), 2) << "Expect" << " median as default";
-
-    EXPECT_FLOAT_EQ(Series({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).quantile(0.3), 2.7)
-                        << "Expect" << " 0.3 quantile";
-
-}
-
-TEST(Series, iloc) {
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series(),
-        Series().iloc(1,3)
-    ) << "Expect " << "empty series";
-
-
-    EXPECT_EQ(
-        Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
-        3
-    ) << "Expect " << " element 3 to be retrieved";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({1, 2}, {1, 2}).iloc(0, 0),
-        Series({}, {})
-    )  << "Expect " << " empty series";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({1, 2}, {1, 2}).iloc(2, 2),
-        Series({}, {})
-    )  << "Expect " << " empty series";
-
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({1, 2}, {1, 2}).iloc(0, 10),
-        Series({1, 2}, {1, 2})
-    )  << "Expect " << " same series since to > series size and from is positive";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({0,1,2,3}, {0,1,2,3}),
-        Series({0,1,2,3}, {0,1,2,3}).iloc(0, 4)
-    ) << "Expect " << " same series since to > series size and from is positive";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({0, 2}, {0, 2}),
-        Series({0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}).iloc(0,4,2)
-    ) << "Expect " << " slice of series with step 2";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(1, 6),
-        Series({8, 9, 10, 11, 12}, {8, 9, 10, 11, 12})
-    ) << "Expect " << " subseries given from and to > 0 ";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({}, {}).iloc(-4, -2),
-        Series({}, {})
-    )  << "Expect " << " empty series input sliced to give empty series";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(2, -1),
-        Series({5}, {5})
-    ) << "Expect " << " third element given positive from, and negative to";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(-3, -1),
-        Series({4, 5}, {4, 5})
-    ) << "Expect " << " middle elements given negative from, and negative to";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({10,11}, {10,11}),
-        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 5)
-    ) << "Expect " << " middle elements given negative from, and positive to";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({12}, {12}),
-        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-1, 6)
-    ) << "Expect " << " last element given negative from, and positive to of the size of the series";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({10, 11, 12}, {10, 11, 12}),
-        Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 6)
-    ) << "Expect " << " last elements given negative from, and positive to of the size of the series";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({3, 4, 5, 6, 7}, {3, 4, 5, 6, 7}).iloc(-3, 0),
-        Series()
-    ) << " empty series";
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(0, -3),
-        Series({3}, {3})
-    ) << " first element given negative value of size of array + 1";
-
-    auto indices = arma::uvec{1, 2};
-
-    EXPECT_PRED2(
-        Series::equal,
-        Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
-        Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
-
-}
-
-TEST(Series, loc) {
-
-    auto labels = arma::vec{3, 4};
-    EXPECT_PRED2(
-            Series::equal,
-            Series({2, 3, 4, 10}, {3, 4, 5, 6}).loc(labels),
-            Series({2, 3}, {3, 4})
-    ) << "Expect " << " indices values retrieved by label";
-
-    auto non_valid_labels = arma::vec{30, 40};
-    EXPECT_PRED2(
-            Series::equal,
-            Series({30, 40, 53, 32}, {3, 4, 5, 6}).loc(non_valid_labels),
-            Series()
-    ) << "Expect " << " empty indices since no records match labels";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(4),
-            Series({30}, {4})
-    ) << "Expect " << "indices values retrieved by label";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(8),
-            Series()
-    ) << "Expect " << "empty indices since no records match label";
-}
-
-TEST(Series, index_as_series) {
-    EXPECT_PRED2(
-            Series::equal,
-            Series().index_as_series(),
-            Series()
-    ) << "Expect " << " empty series";
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series({4, 5, 6, 3}, {1, 2, 3, 4}).index_as_series(),
-            Series({1, 2, 3, 4}, {1, 2, 3, 4})
-    ) << "Expect " << "index as a series";
-}
-
-TEST(Series, from_vect) {
-
-    std::vector<double> z = {1, 2, 3, 4};
-
-    EXPECT_PRED2(
-            Series::equal,
-            Series::from_vect(z, z),
-            Series({1, 2, 3, 4}, {1, 2, 3, 4})
-    ) << "Expect " << "identical indices due to passing vectors";
-
-    std::vector<double> y = {};
-    EXPECT_PRED2(
-            Series::equal,
-            Series::from_vect(y, y),
-            Series({}, {})
-    ) << "Expect " << "identical indices due to passing vectors";
-}
-
-TEST(Series, to_map) {
-
-    Series z = Series({10, 20, 30, 40}, {1, 2, 3, 4});
-
-    int i = 0;
-    for (auto &pair : z.to_map()) {
-        auto key = pair.first;
-        auto value = pair.second;
-
-        EXPECT_EQ(key, z.index()[i]);
-        EXPECT_EQ(value, z.values()[i]);
-        i++;
-    }
-
-    EXPECT_TRUE(Series().to_map().empty());
-}
-
-TEST(Series, head) {
-
-    Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.head(),
-            Series({10, 20, 30, 40, 50}, {1, 2, 3, 4, 5})
-    );
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.head(3),
-            Series({10, 20, 30}, {1, 2, 3,})
-    );
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.head(0),
-            Series()
-    );
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.head(10),
-            z
-    );
-
-}
-
-TEST(Series, tail) {
-
-    Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.tail(),
-            Series({20, 30, 40, 50, 60}, {2, 3, 4, 5, 6})
-    );
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.tail(3),
-            Series({40, 50, 60}, {4, 5, 6})
-    );
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.tail(0),
-            Series()
-    );
-
-    EXPECT_PRED2(
-            Series::equal,
-            z.tail(10),
-            z
-    );
-}
-
-TEST(Series, rolling_window_size_correction){
-
-    arma::vec input_values = {0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1};
-    arma::vec input_timestamps = {1, 2, 3, 4, 5, 6, 7, 8};
-
-    Series new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
-
-    EXPECT_PRED2(
-        Series::equal,
-        new_input_series,
-        Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
-               {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
-    ) << "Expect" << " additional 4 NANs at the beginning for window size even";
-
-    new_input_series = _window_size_correction(11, false, Series(input_values, input_timestamps));
-
-    EXPECT_PRED2(
-        Series::equal,
-        new_input_series,
-        Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
-               {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
-    ) << "Expect" << " additional 4 NANs at the beginning for window size odd";
-
-    input_timestamps = {0, 3, 6, 9, 12, 15, 18, 21};
-
-    new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
-
-    EXPECT_PRED2(
-        Series::equal,
-        new_input_series,
-        Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
-               {-12, -9, -6, -3, 0, 3, 6, 9, 12, 15, 18, 21})
-    ) << "Expect" << " additional 4 NANs at the beginning for window size odd";
-}
-
-TEST(Series, rolling_exp_input_correction){
-
-    EXPECT_PRED2(Series::equal, Series(), _ewm_input_correction({})) << "Expect" << " empty input series to return empty series";
-    EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, 5, 6, 7}, {-2, -1, 0, 1, 2, 3}), _ewm_input_correction({{5, 6, 7}, {1, 2, 3}}));
-    EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, NAN, 5, 6, 7, 8}, {-3, -2, -1, 0, 1, 2, 3, 4}), _ewm_input_correction({{5, 6, 7, 8}, {1, 2, 3, 4}}));
-
-}
-
-TEST(Series, arctan2_regular_case){
-
-    EXPECT_PRED2(
-            Series::almost_equal,
-            Series({0.07677189126977804, 0.5880026035475675, 0.04441521524691084, 0.15534206565122174, 2.214297435588181}, {1, 2, 3, 4, 5}),
-            Series::arctan2(Series({0.1, 0.2, 0.2, 0.83, 0.4}, {1, 2, 3, 4, 5}),
-                            Series({1.3, 0.3, 4.5, 5.3, -0.3}, {1, 2, 3, 4, 5}))
-    ) << "Expect" << " series where each element is the arctan2 of the corresponding series components in x and y.";
-
-}
-
-TEST(Series, concat){
-    EXPECT_PRED2(
-        Series::almost_equal,
-        Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
-        Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6}))
-    ) << "Expect" << " series become concatenated one to the other.";
-
-    EXPECT_PRED2(
-        Series::almost_equal,
-        Series({1,NAN,NAN,4,5,6},{1,2,3,4,5,6}),
-        Series::concat(Series({1,NAN,NAN},{1,2,3}), Series({4,5,6},{4,5,6}))
-    ) << "Expect" << " series become concatenated one to the other even with NANs.";
-
-    EXPECT_PRED2(
-        Series::almost_equal,
-        Series({1,2,3},{1,2,3}),
-        Series::concat(Series({1,2,3},{1,2,3}), Series({},{}))
-    ) << "Expect" << " input series as we are concatenating an empty series.";
-
-    EXPECT_PRED2(
-        Series::almost_equal,
-        Series({1,2,3},{1,2,3}),
-        Series::concat(Series({},{}), Series({1,2,3},{1,2,3}))
-    ) << "Expect" << " input series as we are concatenating an empty series.";
-
-    EXPECT_PRED2(
-        Series::almost_equal,
-        Series(),
-        Series::concat(Series(), Series())
-     ) << "Expect" << " an empty series.";
-}
-
-
-TEST(Series, interval_edges) {
-	// Odd WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 0) == std::make_tuple(0, 0, 1, 1));
-
-	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 1) == std::make_tuple(0, 2, 0, 2));
-
-	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 5) == std::make_tuple(4, 5, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 5) == std::make_tuple(5, 5, 1, 1));
-
-	// Even WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 0) == std::make_tuple(0, 0, 2, 2));
-
-	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 1) == std::make_tuple(0, 2, 1, 3));
-
-	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 6) == std::make_tuple(4, 6, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 6) == std::make_tuple(5, 6, 1, 2));
-
-	// Odd WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 0) == std::make_tuple(0, 0, 1, 1));
-
-	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 1) == std::make_tuple(0, 2, 0, 2));
-
-	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 4) == std::make_tuple(3, 4, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 4) == std::make_tuple(4, 4, 1, 1));
-
-	// Even WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 0) == std::make_tuple(0, 0, 2, 2));
-
-	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 1) == std::make_tuple(0, 2, 1, 3));
-
-	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 5) == std::make_tuple(3, 5, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 5) == std::make_tuple(4, 5, 1, 2));
-
-	// Window = Input
-	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 0) == std::make_tuple(0, 0, 2, 2));
-
-	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 1) == std::make_tuple(0, 2, 1, 3));
-
-	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 3) == std::make_tuple(2, 3, 1, 2));
-}
+		EXPECT_PRED2(
+				Series::equal,
+				Series(),
+				Series().dropna()
+		) << "Expect " << " empty array";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, arma::datum::inf, 3}, {1, 2, 4}),
+				Series({1, arma::datum::inf, NAN, 3}, {1, 2, 3, 4}).dropna()
+		) << "Expect " << " drops NA and preserves inf";
+	}
+
+	TEST(Series, clipTest) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series(arma::vec({}), arma::vec({})).clip(0, 1),
+				Series(arma::vec({}), arma::vec({}))
+		) << "Expect " << "empty Series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(2, 3),
+				Series(arma::vec({2, 2, 3, 3}), arma::vec({1, 2, 3, 4}))
+		) << "Expect " << "indices clipped to 2-3";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series(arma::vec({1, 2, 3, 4}), arma::vec({1, 2, 3, 4})).clip(0, 1),
+				Series(arma::vec({1, 1, 1, 1}), arma::vec({1, 2, 3, 4}))
+		) << "Expect " << "indices clipped to 2-3";
+	}
+
+	TEST(Series, CountTest) {
+		EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).count(), 2)
+							<< "Expect " << "simple count() fixture result to be correct" << "";
+
+		EXPECT_EQ(Series().count(), 0) << "Expect " << "empty series count() should be 0" << "";
+
+		EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).count(), 2)
+							<< "Expect " << "simple count() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+	}
+
+	TEST(Series, SumTest) {
+		EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).sum(), 7)
+							<< "Expect " << "simple sum() fixture result to be correct" << "";
+
+		ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).sum()))
+									<< "Expect " << "empty series sum() should be NAN" << "";
+
+		EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).sum(), 7)
+							<< "Expect " << "simple sum() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+	}
+
+	TEST(Series, MeanTest) {
+		EXPECT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).mean(), 3.5)
+							<< "Expect " << "simple mean() fixture result to be correct" << "";
+
+		ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).mean()))
+									<< "Expect " << "empty series mean() should be NAN" << "";
+
+		EXPECT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).mean(), 3.5)
+							<< "Expect " << "simple mean() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+	}
+
+	TEST(Series, StdTest) {
+		auto root_2 = std::pow(2, .5);
+		EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(), 1 / root_2)
+							<< "Expect " << "simple std() fixture result to be correct" << "";
+
+		EXPECT_FLOAT_EQ(Series(arma::vec({3, 4}), arma::vec({1, 2})).std(0), 0.5)
+							<< "Expect " << "simple std() fixture result to be correct" << "";
+
+		ASSERT_TRUE(std::isnan(Series(arma::vec({}), arma::vec({})).std()))
+									<< "Expect " << "empty series std() should be NAN" << "";
+
+		ASSERT_TRUE(std::isnan(Series(arma::vec({3}), arma::vec({1})).std()))
+									<< "Expect " << "Series with 1 element std() should be NAN";
+
+		EXPECT_FLOAT_EQ(Series(arma::vec({3, NAN, 4}), arma::vec({1, 2, 3})).std(), 1 / root_2)
+							<< "Expect " << "simple std() fixture result with NAN to be correct, ignoring NANs" << "";
+
+
+	}
+
+	TEST(Series, operator__add) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series() + 1,
+				Series()
+		) << "Expect " << "empty Series stays empty";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4}, {1, 2}) + 1,
+				Series({4, 5}, {1, 2})
+		) << "Expect " << "adding 1 increases the values, not the index";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, arma::datum::nan}, {1, 2, 3}) + 1,
+				Series({4, 5, arma::datum::nan}, {1, 2, 3})
+		) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) +
+				Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+				Series({6, -1, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+		) << "Expect " << "adding positive and negative values works and nan results in nan";
+	}
+
+
+	TEST(Series, operator__subtract) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series() - 1,
+				Series()
+		) << "Expect " << "empty Series stays empty";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4}, {1, 2}) - 1,
+				Series({2, 3}, {1, 2})
+		) << "Expect " << "adding 1 increases the values, not the index";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, arma::datum::nan}, {1, 2, 3}) - 1,
+				Series({2, 3, arma::datum::nan}, {1, 2, 3})
+		) << "Expect " << "adding 1 increases the values, not the index, and ignores nan";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) -
+				Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+				Series({-6, 9, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+		) << "Expect " << "subtracting positive and negative values works and nan results in nan";
+	}
+
+
+	TEST(Series, operator__multiply) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series() * 2,
+				Series()
+		) << "Expect " << "empty Series stays empty";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4}, {1, 2}) * 2,
+				Series({6, 8}, {1, 2})
+		) << "Expect " << "multiplying by 2 changes the values, not the index";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, arma::datum::nan}, {1, 2, 3}) * 2,
+				Series({6, 8, arma::datum::nan}, {1, 2, 3})
+		) << "Expect " << "multiplying by 2 changes the values, not the index, and ignores nan";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({-3, 4, 2, arma::datum::nan}, {1, 2, 3, 4}) *
+				Series({3, -5, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4}),
+				Series({-9, -20, arma::datum::nan, arma::datum::nan}, {1, 2, 3, 4})
+		) << "Expect " << "multiplying positive and negative values works and nan results in nan";
+	}
+
+
+	TEST(Series, operator__eq) {
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series() == Series(),
+				polars::SeriesMask()
+		) << "Expect " << "empty Series stays empty";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, 1, 2, NAN}, {1, 2, 3, 4}) ==
+				Series({0, 1, 3, NAN}, {1, 2, 3, 4}),
+				polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
+		) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series() == 1,
+				polars::SeriesMask()
+		) << "Expect " << "empty Series stays empty";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) == 2,
+				polars::SeriesMask({0, 0, 1, 1, 0}, {1, 2, 3, 4, 5})
+		) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+	}
+
+
+	TEST(Series, operator__ne) {
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series() != 1,
+				polars::SeriesMask()
+		) << "Expect " << "empty Series stays empty";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, 1.99, 2, 1 + 1, NAN}, {1, 2, 3, 4, 5}) != 2,
+				polars::SeriesMask({1, 1, 0, 0, 0}, {1, 2, 3, 4, 5})
+		) << "Expect " << "matching should match, but NAN != NAN for the elementwise operator";
+	}
+
+	TEST(Series, operator__gt) {
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series() > Series(),
+				polars::SeriesMask()
+		) << "Expect " << "empty Series stays empty";
+
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >
+				Series({0, -2, 2, NAN}, {1, 2, 3, 4}),
+				polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
+		) << "Expect " << "> should work as per pair, including NAN != NAN";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) >= 0,
+				polars::SeriesMask({1, 0, 1, 0}, {1, 2, 3, 4})
+		) << "Expect " << ">= should work per item, including NAN != NAN";
+	}
+
+	TEST(Series, operator__lt) {
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series() < Series(),
+				polars::SeriesMask()
+		) << "Expect " << "empty Series stays empty";
+
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, -2, 2, NAN}, {1, 2, 3, 4}) <
+				Series({0, -1, 3, NAN}, {1, 2, 3, 4}),
+				polars::SeriesMask({0, 1, 1, 0}, {1, 2, 3, 4})
+		) << "Expect " << "> should work as per pair, including NAN != NAN";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) <= 0,
+				polars::SeriesMask({1, 1, 0, 0}, {1, 2, 3, 4})
+		) << "Expect " << "<= should work per item, including NAN != NAN";
+
+		EXPECT_PRED2(
+				polars::SeriesMask::equal,
+				Series({0, -1, 3, NAN}, {1, 2, 3, 4}) < 0,
+				polars::SeriesMask({0, 1, 0, 0}, {1, 2, 3, 4})
+		) << "Expect " << "< should work per item, including NAN != NAN";
+	}
+
+
+	TEST(Series, apply) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1., 2., 3.}, {1, 2, 3}),
+				Series({1., 2., 3.}, {1, 2, 3}).apply(abs)
+		) << "Expect " << " should remain ideantical";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1., 2., 3.}, {1, 2, 3}),
+				Series({-1., -2., -3.}, {1, 2, 3}).apply(abs)
+		) << "Expect " << " should flip signs";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({2.7182818284590451, 7.3890560989306504, 20.085536923187668}, {1, 2, 3}),
+				Series({1., 2., 3.}, {1, 2, 3}).apply(exp)
+		) << "Expect " << " should apply exponential";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({0, 0.19, 1.9, 1.9}, {1, 2, 3, 4}).apply(exp),
+				Series({1., 1.2092495976572515, 6.6858944422792685, 6.6858944422792685}, {1, 2, 3, 4})
+		) << "Expect " << " should apply exponential";
+
+	}
+
+	TEST(Series, quantile) {
+
+		EXPECT_TRUE(std::isnan(Series().quantile())) << "Expect" << " NAN for empty array";
+
+		EXPECT_EQ(Series({1}, {1}).quantile(1), 1) << "Expect" << " one";
+
+		EXPECT_EQ(Series({1, 2, 3}, {1, 2, 3}).quantile(), 2) << "Expect" << " median as default";
+
+		EXPECT_FLOAT_EQ(Series({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}).quantile(0.3), 2.7)
+							<< "Expect" << " 0.3 quantile";
+
+	}
+
+	TEST(Series, iloc) {
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series(),
+				Series().iloc(1,3)
+		) << "Expect " << "empty series";
+
+
+		EXPECT_EQ(
+				Series({1, 2, 3, 4}, {1, 2, 3, 4}).iloc(2),
+				3
+		) << "Expect " << " element 3 to be retrieved";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 2}, {1, 2}).iloc(0, 0),
+				Series({}, {})
+		)  << "Expect " << " empty series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 2}, {1, 2}).iloc(2, 2),
+				Series({}, {})
+		)  << "Expect " << " empty series";
+
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({1, 2}, {1, 2}).iloc(0, 10),
+				Series({1, 2}, {1, 2})
+		)  << "Expect " << " same series since to > series size and from is positive";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({0,1,2,3}, {0,1,2,3}),
+				Series({0,1,2,3}, {0,1,2,3}).iloc(0, 4)
+		) << "Expect " << " same series since to > series size and from is positive";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({0, 2}, {0, 2}),
+				Series({0, 1, 2, 3, 4, 5, 6, 7}, {0, 1, 2, 3, 4, 5, 6, 7}).iloc(0,4,2)
+		) << "Expect " << " slice of series with step 2";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(1, 6),
+				Series({8, 9, 10, 11, 12}, {8, 9, 10, 11, 12})
+		) << "Expect " << " subseries given from and to > 0 ";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({}, {}).iloc(-4, -2),
+				Series({}, {})
+		)  << "Expect " << " empty series input sliced to give empty series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(2, -1),
+				Series({5}, {5})
+		) << "Expect " << " third element given positive from, and negative to";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(-3, -1),
+				Series({4, 5}, {4, 5})
+		) << "Expect " << " middle elements given negative from, and negative to";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({10,11}, {10,11}),
+				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 5)
+		) << "Expect " << " middle elements given negative from, and positive to";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({12}, {12}),
+				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-1, 6)
+		) << "Expect " << " last element given negative from, and positive to of the size of the series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({10, 11, 12}, {10, 11, 12}),
+				Series({7, 8, 9, 10, 11, 12}, {7, 8, 9, 10, 11, 12}).iloc(-3, 6)
+		) << "Expect " << " last elements given negative from, and positive to of the size of the series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, 5, 6, 7}, {3, 4, 5, 6, 7}).iloc(-3, 0),
+				Series()
+		) << " empty series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({3, 4, 5, 6}, {3, 4, 5, 6}).iloc(0, -3),
+				Series({3}, {3})
+		) << " first element given negative value of size of array + 1";
+
+		auto indices = arma::uvec{1, 2};
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({20, 40, 34, 10}, {1, 2, 3, 4}).iloc(indices),
+				Series({40, 34}, {2, 3})) << "Expect " << "subset including specified indices to be retrieved";
+
+	}
+
+	TEST(Series, loc) {
+
+		auto labels = arma::vec{3, 4};
+		EXPECT_PRED2(
+				Series::equal,
+				Series({2, 3, 4, 10}, {3, 4, 5, 6}).loc(labels),
+				Series({2, 3}, {3, 4})
+		) << "Expect " << " indices values retrieved by label";
+
+		auto non_valid_labels = arma::vec{30, 40};
+		EXPECT_PRED2(
+				Series::equal,
+				Series({30, 40, 53, 32}, {3, 4, 5, 6}).loc(non_valid_labels),
+				Series()
+		) << "Expect " << " empty indices since no records match labels";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(4),
+				Series({30}, {4})
+		) << "Expect " << "indices values retrieved by label";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({10, 30, 40, 20}, {3, 4, 5, 6}).loc(8),
+				Series()
+		) << "Expect " << "empty indices since no records match label";
+	}
+
+	TEST(Series, index_as_series) {
+		EXPECT_PRED2(
+				Series::equal,
+				Series().index_as_series(),
+				Series()
+		) << "Expect " << " empty series";
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series({4, 5, 6, 3}, {1, 2, 3, 4}).index_as_series(),
+				Series({1, 2, 3, 4}, {1, 2, 3, 4})
+		) << "Expect " << "index as a series";
+	}
+
+	TEST(Series, from_vect) {
+
+		std::vector<double> z = {1, 2, 3, 4};
+
+		EXPECT_PRED2(
+				Series::equal,
+				Series::from_vect(z, z),
+				Series({1, 2, 3, 4}, {1, 2, 3, 4})
+		) << "Expect " << "identical indices due to passing vectors";
+
+		std::vector<double> y = {};
+		EXPECT_PRED2(
+				Series::equal,
+				Series::from_vect(y, y),
+				Series({}, {})
+		) << "Expect " << "identical indices due to passing vectors";
+	}
+
+	TEST(Series, to_map) {
+
+		Series z = Series({10, 20, 30, 40}, {1, 2, 3, 4});
+
+		int i = 0;
+		for (auto &pair : z.to_map()) {
+			auto key = pair.first;
+			auto value = pair.second;
+
+			EXPECT_EQ(key, z.index()[i]);
+			EXPECT_EQ(value, z.values()[i]);
+			i++;
+		}
+
+		EXPECT_TRUE(Series().to_map().empty());
+	}
+
+	TEST(Series, head) {
+
+		Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.head(),
+				Series({10, 20, 30, 40, 50}, {1, 2, 3, 4, 5})
+		);
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.head(3),
+				Series({10, 20, 30}, {1, 2, 3,})
+		);
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.head(0),
+				Series()
+		);
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.head(10),
+				z
+		);
+
+	}
+
+	TEST(Series, tail) {
+
+		Series z = Series({10, 20, 30, 40, 50, 60}, {1, 2, 3, 4, 5, 6});
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.tail(),
+				Series({20, 30, 40, 50, 60}, {2, 3, 4, 5, 6})
+		);
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.tail(3),
+				Series({40, 50, 60}, {4, 5, 6})
+		);
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.tail(0),
+				Series()
+		);
+
+		EXPECT_PRED2(
+				Series::equal,
+				z.tail(10),
+				z
+		);
+	}
+
+	TEST(Series, rolling_window_size_correction){
+
+		arma::vec input_values = {0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1};
+		arma::vec input_timestamps = {1, 2, 3, 4, 5, 6, 7, 8};
+
+		Series new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
+
+		EXPECT_PRED2(
+				Series::equal,
+				new_input_series,
+				Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+					   {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
+		) << "Expect" << " additional 4 NANs at the beginning for window size even";
+
+		new_input_series = _window_size_correction(11, false, Series(input_values, input_timestamps));
+
+		EXPECT_PRED2(
+				Series::equal,
+				new_input_series,
+				Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+					   {-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8})
+		) << "Expect" << " additional 4 NANs at the beginning for window size odd";
+
+		input_timestamps = {0, 3, 6, 9, 12, 15, 18, 21};
+
+		new_input_series = _window_size_correction(10, false, Series(input_values, input_timestamps));
+
+		EXPECT_PRED2(
+				Series::equal,
+				new_input_series,
+				Series({NAN, NAN, NAN, NAN, 0.1, 0.3, 0.5, 0.4, 0.7, 0.9, 0.3, 0.1},
+					   {-12, -9, -6, -3, 0, 3, 6, 9, 12, 15, 18, 21})
+		) << "Expect" << " additional 4 NANs at the beginning for window size odd";
+	}
+
+	TEST(Series, rolling_exp_input_correction){
+
+		EXPECT_PRED2(Series::equal, Series(), _ewm_input_correction({})) << "Expect" << " empty input series to return empty series";
+		EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, 5, 6, 7}, {-2, -1, 0, 1, 2, 3}), _ewm_input_correction({{5, 6, 7}, {1, 2, 3}}));
+		EXPECT_PRED2(Series::equal, Series({NAN, NAN, NAN, NAN, 5, 6, 7, 8}, {-3, -2, -1, 0, 1, 2, 3, 4}), _ewm_input_correction({{5, 6, 7, 8}, {1, 2, 3, 4}}));
+
+	}
+
+	TEST(Series, arctan2_regular_case){
+
+		EXPECT_PRED2(
+				Series::almost_equal,
+				Series({0.07677189126977804, 0.5880026035475675, 0.04441521524691084, 0.15534206565122174, 2.214297435588181}, {1, 2, 3, 4, 5}),
+				Series::arctan2(Series({0.1, 0.2, 0.2, 0.83, 0.4}, {1, 2, 3, 4, 5}),
+								Series({1.3, 0.3, 4.5, 5.3, -0.3}, {1, 2, 3, 4, 5}))
+		) << "Expect" << " series where each element is the arctan2 of the corresponding series components in x and y.";
+
+	}
+
+	TEST(Series, concat){
+		EXPECT_PRED2(
+				Series::almost_equal,
+				Series({1,2,3,4,5,6},{1,2,3,4,5,6}),
+				Series::concat(Series({1,2,3},{1,2,3}), Series({4,5,6},{4,5,6}))
+		) << "Expect" << " series become concatenated one to the other.";
+
+		EXPECT_PRED2(
+				Series::almost_equal,
+				Series({1,NAN,NAN,4,5,6},{1,2,3,4,5,6}),
+				Series::concat(Series({1,NAN,NAN},{1,2,3}), Series({4,5,6},{4,5,6}))
+		) << "Expect" << " series become concatenated one to the other even with NANs.";
+
+		EXPECT_PRED2(
+				Series::almost_equal,
+				Series({1,2,3},{1,2,3}),
+				Series::concat(Series({1,2,3},{1,2,3}), Series({},{}))
+		) << "Expect" << " input series as we are concatenating an empty series.";
+
+		EXPECT_PRED2(
+				Series::almost_equal,
+				Series({1,2,3},{1,2,3}),
+				Series::concat(Series({},{}), Series({1,2,3},{1,2,3}))
+		) << "Expect" << " input series as we are concatenating an empty series.";
+
+		EXPECT_PRED2(
+				Series::almost_equal,
+				Series(),
+				Series::concat(Series(), Series())
+		) << "Expect" << " an empty series.";
+	}
+
+/* THIS IS HOW WE WOULD LIKE IT TO BEHAVE FOR center = false.
+TEST(Series, interval_edges_new) {
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 1) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 2) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
+}*/
+
+	TEST(Series, interval_edges) {
+		// Odd WindowSize Even Input
+		EXPECT_TRUE(_get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
+		EXPECT_TRUE(_get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+		EXPECT_TRUE(_get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
+		EXPECT_TRUE(_get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+		EXPECT_TRUE(_get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
+		EXPECT_TRUE(_get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
+
+		// Even WindowSize Odd Input
+		EXPECT_TRUE(_get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
+		EXPECT_TRUE(_get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+		EXPECT_TRUE(_get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
+		EXPECT_TRUE(_get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+		EXPECT_TRUE(_get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
+		EXPECT_TRUE(_get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
+
+		// Odd WindowSize Odd Input
+		EXPECT_TRUE(_get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
+		EXPECT_TRUE(_get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+		EXPECT_TRUE(_get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
+		EXPECT_TRUE(_get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+		EXPECT_TRUE(_get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
+		EXPECT_TRUE(_get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
+
+		// Even WindowSize Even Input
+		EXPECT_TRUE(_get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
+		EXPECT_TRUE(_get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+		EXPECT_TRUE(_get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
+		EXPECT_TRUE(_get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+		EXPECT_TRUE(_get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
+		EXPECT_TRUE(_get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
+
+		// Window = Input
+		EXPECT_TRUE(_get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
+		EXPECT_TRUE(_get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+		EXPECT_TRUE(_get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
+		EXPECT_TRUE(_get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+		EXPECT_TRUE(_get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
+		EXPECT_TRUE(_get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
+	}
+
+
+
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -806,4 +806,56 @@ TEST(Series, concat){
      ) << "Expect" << " an empty series.";
 }
 
+
+TEST(Series, interval_edges) {
+	// Odd WindowSize Even Input
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 5) == std::make_tuple(4, 5, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 5) == std::make_tuple(5, 5, 1, 1));
+
+	// Even WindowSize Odd Input
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 6) == std::make_tuple(4, 6, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 6) == std::make_tuple(5, 6, 1, 2));
+
+	// Odd WindowSize Odd Input
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 4) == std::make_tuple(3, 4, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 4) == std::make_tuple(4, 4, 1, 1));
+
+	// Even WindowSize Even Input
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 5) == std::make_tuple(3, 5, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 5) == std::make_tuple(4, 5, 1, 2));
+
+	// Window = Input
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 3) == std::make_tuple(2, 3, 1, 2));
+}
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -806,4 +806,58 @@ TEST(Series, concat){
      ) << "Expect" << " an empty series.";
 }
 
+TEST(Series, interval_edges) {
+	// Odd WindowSize Even Input
+	EXPECT_TRUE(get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+	EXPECT_TRUE(get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+	EXPECT_TRUE(get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
+
+	// Even WindowSize Odd Input
+	EXPECT_TRUE(get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
+
+	// Odd WindowSize Odd Input
+	EXPECT_TRUE(get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
+
+	EXPECT_TRUE(get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
+
+	EXPECT_TRUE(get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
+
+	// Even WindowSize Even Input
+	EXPECT_TRUE(get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
+
+	// Window = Input
+	EXPECT_TRUE(get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
+
+	EXPECT_TRUE(get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
+
+	EXPECT_TRUE(get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
+}
+
+
+
 } // namespace SeriesTests

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -812,59 +812,59 @@ TEST(Series, interval_edges_new) {
 	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 1) == std::make_tuple(0, 1, 1, 2));
 	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 2) == std::make_tuple(0, 2, 0, 2));
 	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
 }*/
 
 TEST(Series, interval_edges) {
 	// Odd WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 0) == std::make_tuple(0, 0, 1, 1));
+	EXPECT_TRUE(_get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
 
-	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
 
-	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 5) == std::make_tuple(4, 5, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 5) == std::make_tuple(5, 5, 1, 1));
+	EXPECT_TRUE(_get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
+	EXPECT_TRUE(_get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
 
 	// Even WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 6) == std::make_tuple(4, 6, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 6) == std::make_tuple(5, 6, 1, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
 
 	// Odd WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 0) == std::make_tuple(0, 0, 1, 1));
+	EXPECT_TRUE(_get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
 
-	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
 
-	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 4) == std::make_tuple(3, 4, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 4) == std::make_tuple(4, 4, 1, 1));
+	EXPECT_TRUE(_get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
+	EXPECT_TRUE(_get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
 
 	// Even WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 5) == std::make_tuple(3, 5, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 5) == std::make_tuple(4, 5, 1, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
 
 	// Window = Input
-	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(_get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 3) == std::make_tuple(2, 3, 1, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(_get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
 }
 
 

--- a/tests/test_cpp/polars/TestSeries.cpp
+++ b/tests/test_cpp/polars/TestSeries.cpp
@@ -806,56 +806,65 @@ TEST(Series, concat){
      ) << "Expect" << " an empty series.";
 }
 
+/* THIS IS HOW WE WOULD LIKE IT TO BEHAVE FOR center = false.
+TEST(Series, interval_edges_new) {
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 1) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 2) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, false, false, 4) == std::make_tuple(2, 4, 0, 2));
+}*/
+
 TEST(Series, interval_edges) {
 	// Odd WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(3, 6, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, 0) == std::make_tuple(0, 0, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 0) == std::make_tuple(0, 0, 1, 1));
 
-	EXPECT_TRUE(get_interval_edges(3, 6, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 1) == std::make_tuple(0, 2, 0, 2));
 
-	EXPECT_TRUE(get_interval_edges(3, 6, false, 5) == std::make_tuple(4, 5, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 6, true, 5) == std::make_tuple(5, 5, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, false, 5) == std::make_tuple(4, 5, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 6, true, true, 5) == std::make_tuple(5, 5, 1, 1));
 
 	// Even WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(4, 7, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 7, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 7, false, 6) == std::make_tuple(4, 6, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 7, true, 6) == std::make_tuple(5, 6, 1, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, false, 6) == std::make_tuple(4, 6, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 7, true, true, 6) == std::make_tuple(5, 6, 1, 2));
 
 	// Odd WindowSize Odd Input
-	EXPECT_TRUE(get_interval_edges(3, 5, false, 0) == std::make_tuple(0, 1, 1, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, 0) == std::make_tuple(0, 0, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 0) == std::make_tuple(0, 1, 1, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 0) == std::make_tuple(0, 0, 1, 1));
 
-	EXPECT_TRUE(get_interval_edges(3, 5, false, 1) == std::make_tuple(0, 2, 0, 2));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 1) == std::make_tuple(0, 2, 0, 2));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 1) == std::make_tuple(0, 2, 0, 2));
 
-	EXPECT_TRUE(get_interval_edges(3, 5, false, 4) == std::make_tuple(3, 4, 0, 1));
-	EXPECT_TRUE(get_interval_edges(3, 5, true, 4) == std::make_tuple(4, 4, 1, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, false, 4) == std::make_tuple(3, 4, 0, 1));
+	EXPECT_TRUE(get_interval_edges(3, 5, true, true, 4) == std::make_tuple(4, 4, 1, 1));
 
 	// Even WindowSize Even Input
-	EXPECT_TRUE(get_interval_edges(4, 6, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 6, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 6, false, 5) == std::make_tuple(3, 5, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 6, true, 5) == std::make_tuple(4, 5, 1, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, false, 5) == std::make_tuple(3, 5, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 6, true, true, 5) == std::make_tuple(4, 5, 1, 2));
 
 	// Window = Input
-	EXPECT_TRUE(get_interval_edges(4, 4, false, 0) == std::make_tuple(0, 1, 2, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, 0) == std::make_tuple(0, 0, 2, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 0) == std::make_tuple(0, 1, 2, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 0) == std::make_tuple(0, 0, 2, 2));
 
-	EXPECT_TRUE(get_interval_edges(4, 4, false, 1) == std::make_tuple(0, 2, 1, 3));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 1) == std::make_tuple(0, 2, 1, 3));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 1) == std::make_tuple(0, 2, 1, 3));
 
-	EXPECT_TRUE(get_interval_edges(4, 4, false, 3) == std::make_tuple(1, 3, 0, 2));
-	EXPECT_TRUE(get_interval_edges(4, 4, true, 3) == std::make_tuple(2, 3, 1, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, false, 3) == std::make_tuple(1, 3, 0, 2));
+	EXPECT_TRUE(get_interval_edges(4, 4, true, true, 3) == std::make_tuple(2, 3, 1, 2));
 }
 
 

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -14,6 +14,60 @@
 namespace WindowProcessorTests {
 using Series = polars::Series;
 
+// Tests for rolling median
+/*
+TEST(Series, rolling_median_center_false_sym_false){
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, false, false).median(),
+		Series({NAN, NAN, 2.0, 3.0, 4.0}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with odd window and odd input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, false, false).median(),
+			Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
+	) << "Expect " << " output to match pandas with odd window and even input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4}, {1,2,3,4}).rolling(3, false, false).median(),
+			Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
+	) << "Expect " << " output to match pandas with odd window and even input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, false, false).median(),
+			Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
+	) << "Expect " << " output to match pandas with even window and even input.";
+
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, false, false).median(),
+			Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with even window and odd input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3}, {1,2,3}).rolling(2, false, false).median(),
+			Series({NAN, 1.5, 2.5}, {1,2,3})
+	) << "Expect " << " output to match pandas with even window and odd input.";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, false, false).median(),
+			Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with windowSize = inputSize";
+
+	EXPECT_PRED2(
+			Series::equal,
+			Series({1,2,3,4}, {1,2,3,4}).rolling(5, false, false).median(),
+			Series({NAN, NAN, NAN, NAN, 2.5}, {1,2,3,4})
+	) << "Expect " << " output to match pandas with windowSize = inputSize";
+}*/
+
+
 TEST(Series, RollingQuantileTest) {
     EXPECT_PRED2(Series::equal, Series(arma::vec({}), arma::vec({})),
                  Series(arma::vec({}), arma::vec({})).rolling(3, polars::Quantile(0.5)))

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -6,7 +6,6 @@
 
 #include "polars/Series.h"
 #include "polars/SeriesMask.h"
-#include "polars/numc.h"
 
 #include "gtest/gtest.h"
 
@@ -15,57 +14,156 @@ namespace WindowProcessorTests {
 using Series = polars::Series;
 
 // Tests for rolling median
-/*
-TEST(Series, rolling_median_center_false_sym_false){
+
+TEST(Series, rolling_median_nans){
 	EXPECT_PRED2(
 		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, false, false).median(),
+		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(1, polars::Quantile(0.5), 0, false, false),
+		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6})
+	) << "Expect " << " return input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(1, polars::Quantile(0.5), 0, true, false),
+		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6})
+	) << "Expect " << " return input";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(3, polars::Quantile(0.5), 0, false, false),
+		Series({NAN, NAN, NAN, NAN, NAN, 5.0}, {1,2,3,4,5,6})
+	) << "Expect " << " odd window on even input to match pandas with center=false";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(3, polars::Quantile(0.5), 0, true, false),
+		Series({NAN, NAN, NAN, NAN, 5.0, NAN}, {1,2,3,4,5,6})
+	) << "Expect " << " odd window on even input to match pandas with center=true";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,NAN,NAN,5,6}, {1,2,3,4,5,6}).rolling(2, polars::Quantile(0.5), 0, true, false),
+		Series({NAN, 1.5, NAN, NAN, NAN, 5.5}, {1,2,3,4,5,6})
+	) << "Expect " << " even window on even input to match pandas with center=true";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,NAN,NAN,5,6}, {1,2,3,4,5,6}).rolling(2, polars::Quantile(0.5), 0, false, false),
+		Series({NAN, 1.5, NAN, NAN, NAN, 5.5}, {1,2,3,4,5,6})
+	) << "Expect " << " even window on even input to match pandas with center=true";
+}
+
+
+TEST(Series, rolling_median_center_false_sym_false){
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, 0, false, false).median(),
 		Series({NAN, NAN, 2.0, 3.0, 4.0}, {1,2,3,4,5})
 	) << "Expect " << " output to match pandas with odd window and odd input.";
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, false, false).median(),
-			Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
+		Series::equal,
+		Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, 0, false, false).median(),
+		Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
 	) << "Expect " << " output to match pandas with odd window and even input.";
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4}, {1,2,3,4}).rolling(3, false, false).median(),
-			Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
+		Series::equal,
+		Series({1,2,3,4}, {1,2,3,4}).rolling(3, 0, false, false).median(),
+		Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
 	) << "Expect " << " output to match pandas with odd window and even input.";
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, false, false).median(),
-			Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
+		Series::equal,
+		Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, 0, false, false).mean(),
+		Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
 	) << "Expect " << " output to match pandas with even window and even input.";
 
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, false, false).median(),
-			Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, 0, false, false).median(),
+		Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
 	) << "Expect " << " output to match pandas with even window and odd input.";
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3}, {1,2,3}).rolling(2, false, false).median(),
-			Series({NAN, 1.5, 2.5}, {1,2,3})
+		Series::equal,
+		Series({1,2,3}, {1,2,3}).rolling(2, 0, false, false).median(),
+		Series({NAN, 1.5, 2.5}, {1,2,3})
 	) << "Expect " << " output to match pandas with even window and odd input.";
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, false, false).median(),
-			Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, 0, false, false).median(),
+		Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
 	) << "Expect " << " output to match pandas with windowSize = inputSize";
 
 	EXPECT_PRED2(
-			Series::equal,
-			Series({1,2,3,4}, {1,2,3,4}).rolling(5, false, false).median(),
-			Series({NAN, NAN, NAN, NAN, 2.5}, {1,2,3,4})
+		Series::equal,
+		Series({1,2,3,4}, {1,2,3,4}).rolling(4, 0, false, false).median(),
+		Series({NAN, NAN, NAN, 2.5}, {1,2,3,4})
 	) << "Expect " << " output to match pandas with windowSize = inputSize";
-}*/
+}
+
+
+TEST(Series, rolling_median_center_true_sym_false){
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, polars::Quantile(0.5), 0, true, false),
+		Series({NAN, 2.0, 3.0, 4.0, NAN}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with odd window and odd input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, 0, true, false).median(),
+		Series({NAN, 2.0, 3.0, 4.0, NAN}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with odd window and odd input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, 0, true, false).median(),
+		Series({NAN, 2.0, 3.0, 4.0, 5.0, NAN}, {1,2,3,4,5,6})
+	) << "Expect " << " output to match pandas with odd window and even input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4}, {1,2,3,4}).rolling(3, 0, true, false).median(),
+		Series({NAN, 2.0, 3.0, NAN}, {1,2,3,4})
+	) << "Expect " << " output to match pandas with odd window and even input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, 0, true, false).mean(),
+		Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
+	) << "Expect " << " output to match pandas with even window and even input.";
+
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, 0, true, false).median(),
+		Series({NAN, NAN, 2.5, 3.5, NAN}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with even window and odd input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3}, {1,2,3}).rolling(2, 0, true, false).median(),
+		Series({NAN, 1.5, 2.5}, {1,2,3})
+	) << "Expect " << " output to match pandas with even window and odd input.";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, 0, true, false).median(),
+		Series({NAN, NAN, 3.0, NAN, NAN}, {1,2,3,4,5})
+	) << "Expect " << " output to match pandas with windowSize = inputSize";
+
+	EXPECT_PRED2(
+		Series::equal,
+		Series({1,2,3,4}, {1,2,3,4}).rolling(4, 0, true, false).median(),
+		Series({NAN, NAN, 2.5, NAN}, {1,2,3,4})
+	) << "Expect " << " output to match pandas with windowSize = inputSize";
+}
 
 
 TEST(Series, RollingQuantileTest) {

--- a/tests/test_cpp/polars/TestWindowProcessor.cpp
+++ b/tests/test_cpp/polars/TestWindowProcessor.cpp
@@ -16,153 +16,153 @@ using Series = polars::Series;
 // Tests for rolling median
 
 TEST(Series, rolling_median_nans){
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(1, polars::Quantile(0.5), 0, false, false),
-		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6})
-	) << "Expect " << " return input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(1, polars::Quantile(0.5), 0, false, false),
+        Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6})
+    ) << "Expect " << " return input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(1, polars::Quantile(0.5), 0, true, false),
-		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6})
-	) << "Expect " << " return input";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(1, polars::Quantile(0.5), 0, true, false),
+        Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6})
+    ) << "Expect " << " return input";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(3, polars::Quantile(0.5), 0, false, false),
-		Series({NAN, NAN, NAN, NAN, NAN, 5.0}, {1,2,3,4,5,6})
-	) << "Expect " << " odd window on even input to match pandas with center=false";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(3, polars::Quantile(0.5), 0, false, false),
+        Series({NAN, NAN, NAN, NAN, NAN, 5.0}, {1,2,3,4,5,6})
+    ) << "Expect " << " odd window on even input to match pandas with center=false";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(3, polars::Quantile(0.5), 0, true, false),
-		Series({NAN, NAN, NAN, NAN, 5.0, NAN}, {1,2,3,4,5,6})
-	) << "Expect " << " odd window on even input to match pandas with center=true";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,NAN,4,5,6}, {1,2,3,4,5,6}).rolling(3, polars::Quantile(0.5), 0, true, false),
+        Series({NAN, NAN, NAN, NAN, 5.0, NAN}, {1,2,3,4,5,6})
+    ) << "Expect " << " odd window on even input to match pandas with center=true";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,NAN,NAN,5,6}, {1,2,3,4,5,6}).rolling(2, polars::Quantile(0.5), 0, true, false),
-		Series({NAN, 1.5, NAN, NAN, NAN, 5.5}, {1,2,3,4,5,6})
-	) << "Expect " << " even window on even input to match pandas with center=true";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,NAN,NAN,5,6}, {1,2,3,4,5,6}).rolling(2, polars::Quantile(0.5), 0, true, false),
+        Series({NAN, 1.5, NAN, NAN, NAN, 5.5}, {1,2,3,4,5,6})
+    ) << "Expect " << " even window on even input to match pandas with center=true";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,NAN,NAN,5,6}, {1,2,3,4,5,6}).rolling(2, polars::Quantile(0.5), 0, false, false),
-		Series({NAN, 1.5, NAN, NAN, NAN, 5.5}, {1,2,3,4,5,6})
-	) << "Expect " << " even window on even input to match pandas with center=true";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,NAN,NAN,5,6}, {1,2,3,4,5,6}).rolling(2, polars::Quantile(0.5), 0, false, false),
+        Series({NAN, 1.5, NAN, NAN, NAN, 5.5}, {1,2,3,4,5,6})
+    ) << "Expect " << " even window on even input to match pandas with center=true";
 }
 
 
 TEST(Series, rolling_median_center_false_sym_false){
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, 0, false, false).median(),
-		Series({NAN, NAN, 2.0, 3.0, 4.0}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with odd window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, 0, false, false).median(),
+        Series({NAN, NAN, 2.0, 3.0, 4.0}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with odd window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, 0, false, false).median(),
-		Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
-	) << "Expect " << " output to match pandas with odd window and even input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, 0, false, false).median(),
+        Series({NAN, NAN, 2.0, 3.0, 4.0, 5.0}, {1,2,3,4,5,6})
+    ) << "Expect " << " output to match pandas with odd window and even input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4}, {1,2,3,4}).rolling(3, 0, false, false).median(),
-		Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
-	) << "Expect " << " output to match pandas with odd window and even input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4}, {1,2,3,4}).rolling(3, 0, false, false).median(),
+        Series({NAN, NAN, 2.0, 3.0}, {1,2,3,4})
+    ) << "Expect " << " output to match pandas with odd window and even input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, 0, false, false).mean(),
-		Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
-	) << "Expect " << " output to match pandas with even window and even input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, 0, false, false).mean(),
+        Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
+    ) << "Expect " << " output to match pandas with even window and even input.";
 
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, 0, false, false).median(),
-		Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with even window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, 0, false, false).median(),
+        Series({NAN, NAN, NAN, 2.5, 3.5}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with even window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3}, {1,2,3}).rolling(2, 0, false, false).median(),
-		Series({NAN, 1.5, 2.5}, {1,2,3})
-	) << "Expect " << " output to match pandas with even window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3}, {1,2,3}).rolling(2, 0, false, false).median(),
+        Series({NAN, 1.5, 2.5}, {1,2,3})
+    ) << "Expect " << " output to match pandas with even window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, 0, false, false).median(),
-		Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with windowSize = inputSize";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, 0, false, false).median(),
+        Series({NAN, NAN, NAN, NAN, 3.0}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with windowSize = inputSize";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4}, {1,2,3,4}).rolling(4, 0, false, false).median(),
-		Series({NAN, NAN, NAN, 2.5}, {1,2,3,4})
-	) << "Expect " << " output to match pandas with windowSize = inputSize";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4}, {1,2,3,4}).rolling(4, 0, false, false).median(),
+        Series({NAN, NAN, NAN, 2.5}, {1,2,3,4})
+    ) << "Expect " << " output to match pandas with windowSize = inputSize";
 }
 
 
 TEST(Series, rolling_median_center_true_sym_false){
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, polars::Quantile(0.5), 0, true, false),
-		Series({NAN, 2.0, 3.0, 4.0, NAN}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with odd window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, polars::Quantile(0.5), 0, true, false),
+        Series({NAN, 2.0, 3.0, 4.0, NAN}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with odd window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, 0, true, false).median(),
-		Series({NAN, 2.0, 3.0, 4.0, NAN}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with odd window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(3, 0, true, false).median(),
+        Series({NAN, 2.0, 3.0, 4.0, NAN}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with odd window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, 0, true, false).median(),
-		Series({NAN, 2.0, 3.0, 4.0, 5.0, NAN}, {1,2,3,4,5,6})
-	) << "Expect " << " output to match pandas with odd window and even input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5,6}, {1,2,3,4,5,6}).rolling(3, 0, true, false).median(),
+        Series({NAN, 2.0, 3.0, 4.0, 5.0, NAN}, {1,2,3,4,5,6})
+    ) << "Expect " << " output to match pandas with odd window and even input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4}, {1,2,3,4}).rolling(3, 0, true, false).median(),
-		Series({NAN, 2.0, 3.0, NAN}, {1,2,3,4})
-	) << "Expect " << " output to match pandas with odd window and even input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4}, {1,2,3,4}).rolling(3, 0, true, false).median(),
+        Series({NAN, 2.0, 3.0, NAN}, {1,2,3,4})
+    ) << "Expect " << " output to match pandas with odd window and even input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, 0, true, false).mean(),
-		Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
-	) << "Expect " << " output to match pandas with even window and even input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1 ,2 ,3,4}, {1,2,3,4}).rolling(2, 0, true, false).mean(),
+        Series({NAN, 1.5, 2.5, 3.5}, {1, 2, 3, 4})
+    ) << "Expect " << " output to match pandas with even window and even input.";
 
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, 0, true, false).median(),
-		Series({NAN, NAN, 2.5, 3.5, NAN}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with even window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(4, 0, true, false).median(),
+        Series({NAN, NAN, 2.5, 3.5, NAN}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with even window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3}, {1,2,3}).rolling(2, 0, true, false).median(),
-		Series({NAN, 1.5, 2.5}, {1,2,3})
-	) << "Expect " << " output to match pandas with even window and odd input.";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3}, {1,2,3}).rolling(2, 0, true, false).median(),
+        Series({NAN, 1.5, 2.5}, {1,2,3})
+    ) << "Expect " << " output to match pandas with even window and odd input.";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, 0, true, false).median(),
-		Series({NAN, NAN, 3.0, NAN, NAN}, {1,2,3,4,5})
-	) << "Expect " << " output to match pandas with windowSize = inputSize";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4,5}, {1,2,3,4,5}).rolling(5, 0, true, false).median(),
+        Series({NAN, NAN, 3.0, NAN, NAN}, {1,2,3,4,5})
+    ) << "Expect " << " output to match pandas with windowSize = inputSize";
 
-	EXPECT_PRED2(
-		Series::equal,
-		Series({1,2,3,4}, {1,2,3,4}).rolling(4, 0, true, false).median(),
-		Series({NAN, NAN, 2.5, NAN}, {1,2,3,4})
-	) << "Expect " << " output to match pandas with windowSize = inputSize";
+    EXPECT_PRED2(
+        Series::equal,
+        Series({1,2,3,4}, {1,2,3,4}).rolling(4, 0, true, false).median(),
+        Series({NAN, NAN, 2.5, NAN}, {1,2,3,4})
+    ) << "Expect " << " output to match pandas with windowSize = inputSize";
 }
 
 
@@ -778,7 +778,7 @@ TEST(Series, rolling_mean_exponential__varying_window_size){
     Series input = Series(input_values, input_timestamps);
 
     for(int i = 1; i<= 60; i++) {
-    	Series actual = input.ewm(i, 1, false, 0.1);
+        Series actual = input.ewm(i, 1, false, 0.1);
         EXPECT_PRED2(Series::almost_equal, actual, expected) << "Expect " << " matches expectation set by pandas.";
     }
 }
@@ -803,7 +803,7 @@ TEST(Series, rolling_mean_exponential__shorter_window_size){
     actual = Series({5, 6, 7, 8}, {1, 2, 3, 4}).ewm(window_size, 1, false, 1./decay_windows);
 
     EXPECT_PRED2(
-    	Series::almost_equal, actual, Series(expected, {1, 2, 3, 4})
+        Series::almost_equal, actual, Series(expected, {1, 2, 3, 4})
     ) << "Expect " << " for the even/even case matches expectation set by pandas.";
 
     // Odd window size
@@ -813,14 +813,14 @@ TEST(Series, rolling_mean_exponential__shorter_window_size){
     actual = Series({5, 6, 7, 8, 9}, {1, 2, 3, 4, 5}).ewm(window_size, 1, false, 1./decay_windows);
 
     EXPECT_PRED2(
-    	Series::almost_equal, actual, Series(expected, {1, 2, 3, 4, 5})
+        Series::almost_equal, actual, Series(expected, {1, 2, 3, 4, 5})
     ) << "Expect " << " for the odd/odd case matches expectation set by pandas.";
 
     expected = {5.0, 5.666666666666667, 6.428571428571429, 7.266666666666667, 8.161290322580646, 9.095238095238095};
     actual = Series({5, 6, 7, 8, 9, 10}, {1, 2, 3, 4, 5, 6}).ewm(window_size, 1, false, 1./decay_windows);
 
     EXPECT_PRED2(
-    	Series::almost_equal, actual, Series(expected, {1, 2, 3, 4, 5, 6})
+        Series::almost_equal, actual, Series(expected, {1, 2, 3, 4, 5, 6})
     ) << "Expect " << " for the even/odd case matches expectation set by pandas.";
 }
 


### PR DESCRIPTION
This PR builds on top of PR #8. 

- Exponential Rolling Mean is now separate from rolling function, taking away the inherent complexity this operation entails.
- `center=False` now works for rolling. It also ensures it deals with NANs in the correct way. 
- Test coverage has been expanded and looks all various cases of odd/even inputs vs odd/even windows and if window size < input size or window size > input size.

The original intention was to make _get_interval_edges deal with the centring logic, but with NANs in the picture this became more complicated, so this is dealt a posteriori. Tests ensure we have the correct behaviour and they match pandas' results.

Note: On versioning decided to do a minor version bump in PR#8 despite the backwards incompatibility regarding exponential rolling mean, which is no longer supported via the rolling method. I think library is still in the process of development so according to semver, while the major version is in 0, it is ok to expect things to break. @calvingiles if you are not happy with this, I can indeed change this to 1, on this PR.